### PR TITLE
Load JS data from javascript-conference

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 Hey, here is a conference that is missing from the list.
 
 Where should it go?
-- [ ] JavaScript
+- [ ] JavaScript => [Add it to the JavaScript Conference](https://github.com/tech-conferences/javascript-conferences/issues/new)
 - [ ] UX / Design
 - [ ] iOS
 - [ ] Ruby

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,7 +3,6 @@ import {Switch, Route} from 'react-router-dom';
 
 import styles from './App.scss';
 import Head from '../Head';
-import Footer from '../Footer';
 import ConferencePage from '../ConferencePage';
 
 export default function App() {
@@ -18,7 +17,6 @@ export default function App() {
           <Route exact path="/" component={ConferencePage} />
           <Route component={ConferencePage} />
         </Switch>
-        <Footer />
       </div>
     </div>
   );

--- a/src/components/ConferencePage/ConferencePage.js
+++ b/src/components/ConferencePage/ConferencePage.js
@@ -5,13 +5,18 @@ import Favicon from 'react-favicon';
 import {Helmet} from 'react-helmet';
 
 import styles from './ConferencePage.scss';
+import Footer from '../Footer';
 import Link from '../Link';
 import GithubStar from '../GithubStar';
 import Heading from '../Heading';
 import Icon from '../Icon';
 import ConferenceList from '../ConferenceList';
 import ConferenceFilter from '../ConferenceFilter';
-import {TYPES, getConferenceLink} from '../config';
+import {
+  TYPES,
+  getConferenceUrl,
+  getAddConferenceUrl,
+} from '../config';
 
 const CURRENT_YEAR = (new Date()).getFullYear().toString();
 
@@ -55,7 +60,7 @@ export default class ConferencePage extends Component {
 
   loadConference = () => {
     const {lastLinkFetched, conferences, filters} = this.state;
-    const link = getConferenceLink(filters);
+    const link = getConferenceUrl(filters);
 
     if (lastLinkFetched === link) { return conferences; }
 
@@ -117,6 +122,7 @@ export default class ConferencePage extends Component {
     } = this.state;
     const conferencesFilteredByDate = filterConferencesByDate(conferences, showPast);
     const filteredConferences = this.filterConferences(conferencesFilteredByDate);
+    const addConferenceUrl = getAddConferenceUrl(type);
 
     return (
       <div>
@@ -145,6 +151,7 @@ export default class ConferencePage extends Component {
               />
           }
         </div>
+        <Footer addConferenceUrl={addConferenceUrl} />
       </div>
     );
   }

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -3,11 +3,11 @@ import React from 'react';
 import styles from './Footer.scss';
 import Link from '../Link';
 
-export default function Footer() {
+export default function Footer({addConferenceUrl}) {
   return (
     <footer className={styles.Footer}>
       <p>
-        <Link url="https://github.com/tech-conferences/confs.tech/issues/new" external>
+        <Link url={addConferenceUrl} external>
           Add a conference
         </Link>
       </p>

--- a/src/components/config/index.js
+++ b/src/components/config/index.js
@@ -9,9 +9,33 @@ export const TYPES = {
   android: 'Android',
 };
 
-const BASE_URL = 'https://raw.githubusercontent.com/tech-conferences/confs.tech/master/conferences';
+const DEFAULT_URL = 'https://raw.githubusercontent.com/tech-conferences/confs.tech/master/conferences';
 
-export function getConferenceLink(state) {
+const REPO_URLS = {
+  javascript: 'https://github.com/tech-conferences/javascript-conferences',
+  css: 'https://github.com/tech-conferences/confs.tech',
+  ux: 'https://github.com/tech-conferences/confs.tech',
+  ruby: 'https://github.com/tech-conferences/confs.tech',
+  ios: 'https://github.com/tech-conferences/confs.tech',
+  android: 'https://github.com/tech-conferences/confs.tech',
+};
+
+const RAW_CONTENT_URLS = {
+  javascript: 'https://raw.githubusercontent.com/tech-conferences/javascript-conferences/master/conferences',
+  css: DEFAULT_URL,
+  ux: DEFAULT_URL,
+  ruby: DEFAULT_URL,
+  ios: DEFAULT_URL,
+  android: DEFAULT_URL,
+};
+
+export function getConferenceUrl(state) {
   const {type, year} = state;
-  return `${BASE_URL}/${year}/${type.toLocaleLowerCase()}.json`;
+  const _type = type.toLocaleLowerCase();
+
+  return `${RAW_CONTENT_URLS[_type]}/${year}/${_type}.json`;
+}
+
+export function getAddConferenceUrl(type) {
+  return `${REPO_URLS[type.toLocaleLowerCase()]}/issues/new`;
 }


### PR DESCRIPTION
- When adding new conference redirecting to [javascript-conferences repo](https://github.com/tech-conferences/javascript-conferences/issues/new)
- Pulling data from [javascript-conferences repo](https://github.com/tech-conferences/javascript-conferences/issues/new)