### PR TITLE
Force a scrollbar on the root container to prevent horizontal jumps and full-page repaints

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,7 @@
+:global(:root) {
+  overflow-y: scroll;
+}
+
 :global(body) {
   font-family: sans-serif;
   font-size: 16px;


### PR DESCRIPTION
This fixes an issue where on certain machines, the scrollbar would disappear/reappear during page transitions, causing an undesirable jump of the document.

See full explanation here: https://css-tricks.com/eliminate-jumps-in-horizontal-centering-by-forcing-a-scroll-bar/