### PR TITLE
Show if a conference has CFP open

### DIFF
--- a/src/components/ConferenceItem/ConferenceItem.js
+++ b/src/components/ConferenceItem/ConferenceItem.js
@@ -17,6 +17,8 @@ export default class ConferenceItem extends PureComponent {
       startDate,
       endDate,
       twitter,
+      cfpEndDate,
+      cfpUrl,
     } = this.props;
 
     return (
@@ -34,6 +36,7 @@ export default class ConferenceItem extends PureComponent {
           <Link url={url} external>
             {name}
           </Link>
+          <Cfp url={cfpUrl || url} date={cfpEndDate} />
         </Heading>
         <p className={styles.p}>
           {`${Location(city, country)} - `}
@@ -63,4 +66,23 @@ function Location(city, country) {
   }
 
   return country || city;
+}
+
+function Cfp({date, url}) {
+  if (!date || isPast(parse(date))) {
+    return null;
+  }
+
+  return (
+    <span className={styles.cfp}>
+      <Link
+        url={url}
+        external
+        className={styles.cfpTag}
+      >
+        CFP open
+      </Link>
+      {formatDate(parse(date))}
+    </span>
+  );
 }

--- a/src/components/ConferenceItem/ConferenceItem.scss
+++ b/src/components/ConferenceItem/ConferenceItem.scss
@@ -1,4 +1,5 @@
 @import '../style/foundation/spacing.scss';
+@import '../style/foundation/colors.scss';
 
 .ConferenceItem {
   margin-bottom: spacing(base);
@@ -14,4 +15,27 @@
 
 .p {
   margin: 0;
+}
+
+.cfp {
+  font-size: 12px;
+  display: inline-block;
+  color: color(gray);
+}
+
+.cfpTag {
+  border-radius: 2px;
+  padding: 2px 5px;
+  display: inline-block;
+  background-color: color(green);
+  color: white;
+  margin-left: spacing(tight);
+  margin-right: spacing(extra-tight);
+
+  &:hover {
+    background-color: lighten(color(green), 4);
+    &::after {
+      display: none;
+    }
+  }
 }

--- a/src/components/ConferencePage/ConferencePage.js
+++ b/src/components/ConferencePage/ConferencePage.js
@@ -150,9 +150,7 @@ export default class ConferencePage extends Component {
         <div>
           {loading
             ? Loader()
-            : <ConferenceList
-              conferences={filteredConferences}
-              />
+            : <ConferenceList conferences={filteredConferences} />
           }
         </div>
         <Footer

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -7,6 +7,7 @@
   cursor: pointer;
   text-decoration: none;
 
+
   &:hover,
   &.Selected {
     &::after {

--- a/src/components/style/foundation/_colors.scss
+++ b/src/components/style/foundation/_colors.scss
@@ -6,6 +6,9 @@ $color-palette-data: (
   accent: (
     base: #53ACFE,
   ),
+  green: (
+    base: #4caf50,
+  ),
   accent-2: (
     base: #FFCA04,
   ),


### PR DESCRIPTION
Show CFP tag with the cfp end date if the information is in the JSON file.
![image](https://user-images.githubusercontent.com/445045/36347152-1b7c273e-141e-11e8-9a08-fbe264985f34.png)

--- 

Hey @tech-conferences/core , what do you think? Should we have this turn on by default? Should we have a link / toggle somewhere in the page? I'm open to suggestions.
It's clearly a feature a lot of people want, but I am hesitating with having it on by default. And I don't want neither to add too much clutter to the filters on top of the page. The tag is green right now but it could be gray instead for instance:

![image](https://user-images.githubusercontent.com/445045/36347178-9633fb64-141e-11e8-9895-e8bdf90f09f7.png)