### PR TITLE
Add link to send email to add confs

### DIFF
--- a/src/components/ConferenceList/ConferenceList.css
+++ b/src/components/ConferenceList/ConferenceList.css
@@ -17,9 +17,55 @@
   }
 }
 
-.AddConfLink{
+.AddConfPanelWrapper {
+  position: relative;
   display: none;
   @include media($media-query--tablet-up) {
     display: block;
+  }
+
+  &:hover {
+    .AddConfPanel {
+      display: block;
+      animation: fade-in 100ms cubic-bezier(0, 0.85, 1, 1) forwards;
+    }
+  }
+}
+
+.AddConfPanel {
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  margin-top: 0;
+  display: none;
+
+  a {
+    font-size: 0.9rem;
+  }
+
+  ul {
+    margin-top: spacing(tight);
+    padding: 0.5em 0.8em;
+    white-space: nowrap;
+    background-color: white;
+    list-style: none;
+    border: 1px solid #CCC;
+    border-radius: 4px;
+  }
+  li:first-child {
+    margin-bottom: spacing(tight);
+  }
+}
+
+
+@keyframes fade-in {
+  0% {
+    transform: translateY(-10%);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0);
+    opacity: 1;
   }
 }

--- a/src/components/ConferenceList/ConferenceList.js
+++ b/src/components/ConferenceList/ConferenceList.js
@@ -102,9 +102,7 @@ function Year({year, addConferenceUrl}) {
       <Heading key={year} element="h2" level={2}>
         {year}
       </Heading>
-      <Link url={addConferenceUrl} external className={styles.AddConfLink}>
-        Add a conference
-      </Link>
+      <AddConferenceLink url={addConferenceUrl} />
     </div>
   );
 }
@@ -113,4 +111,28 @@ function getConfsMonthsSorted(conferences) {
   return _sortBy(Object.keys(conferences), (conference) => {
     return parseInt(conference.replace('-', ''), 10);
   });
+}
+
+function AddConferenceLink({url}) {
+  return (
+    <div className={styles.AddConfPanelWrapper}>
+      <Link url={url} external>
+        Add a conference
+      </Link>
+      <div className={styles.AddConfPanel}>
+        <ul>
+          <li>
+            <Link url={url} external>
+              Create a github issue
+            </Link>
+          </li>
+          <li>
+            <Link url="mailto:nim.izadi+confs.tech@gmail.com?subject=Here's a cool conference!" external>
+              Send us an email
+            </Link>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Adding a link to add conference by email.
Since you have to have a github account to suggest conference by adding an issue, I want to see if adding a link with a direct email will help.

![add conf](https://user-images.githubusercontent.com/445045/36357998-c88046ac-14d4-11e8-84f4-7cd648115542.gif)

cc @tech-conferences/core 