### PR TITLE
Move UIKonf to iOS from Android

### DIFF
--- a/conferences/2018/android.json
+++ b/conferences/2018/android.json
@@ -96,16 +96,6 @@
     "endDate": "2018-05-10"
   },
   {
-    "name": "UIKonf",
-    "url": "http://www.uikonf.com",
-    "startDate": "2018-05-13",
-    "endDate": "2018-05-16",
-    "city": "Berlin",
-    "country": "Germany",
-    "cfpEndDate": "2018-03-08",
-    "cfpUrl": "http://cfp.uikonf.com/about"
-  },
-  {
     "name": "Voxxed Days",
     "url": "https://voxxeddays.com/minsk",
     "city": "Minsk",

--- a/conferences/2018/ios.json
+++ b/conferences/2018/ios.json
@@ -75,6 +75,16 @@
     "endDate": "2018-04-21"
   },
   {
+    "name": "UIKonf",
+    "url": "http://www.uikonf.com",
+    "startDate": "2018-05-13",
+    "endDate": "2018-05-16",
+    "city": "Berlin",
+    "country": "Germany",
+    "cfpEndDate": "2018-03-08",
+    "cfpUrl": "http://cfp.uikonf.com/about"
+  },
+  {
     "name": "WWDC",
     "url": "https://developer.apple.com/wwdc",
     "startDate": "2018-06-04",


### PR DESCRIPTION
I am one of the organisers of UIKonf. We are an iOS centric conference. While we some time feature cross-platform talks, we did not have a single Android-only talk so far. This move reflects this fact.