### PR TITLE
Removed year from the conference names

### DIFF
--- a/conferences/2016/ux.json
+++ b/conferences/2016/ux.json
@@ -96,7 +96,7 @@
     "city": ""
   },
   {
-    "name": "UXPA 2017",
+    "name": "UXPA",
     "url": "http://uxpa.github.io",
     "date": "June 5 - 8",
     "city": "Toronto",
@@ -193,7 +193,7 @@
     "city": "Malmo, Sweden"
   },
   {
-    "name": "MobileHCI 2017",
+    "name": "MobileHCI",
     "url": "http://mobilehci.acm.org/2017",
     "date": "Sept 4-7",
     "city": "Vienna, Austria"
@@ -337,7 +337,7 @@
     "city": "Washington, DC"
   },
   {
-    "name": "Delight 2018",
+    "name": "Delight",
     "url": "http://delight.us/conference",
     "date": "May 2018",
     "city": ""

--- a/conferences/2017/general.json
+++ b/conferences/2017/general.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Techbash 2017",
+    "name": "Techbash",
     "url": "https://techbash.com",
     "city": "Pennsylvania",
     "country": "U.S.A.",
@@ -8,7 +8,7 @@
     "endDate": "2017-10-06"
   },
   {
-    "name": "GDG DevFest 2017",
+    "name": "GDG DevFest",
     "url": "https://devfest.gdghyderabad.in",
     "city": "Hyderabad",
     "country": "India",

--- a/conferences/2017/ios.json
+++ b/conferences/2017/ios.json
@@ -40,7 +40,7 @@
     "country": "Norway"
   },
   {
-    "name": "Release Notes 2017",
+    "name": "Release Notes",
     "url": "https://2017.releasenotes.tv",
     "startDate": "2017-10-16",
     "endDate": "2017-10-18",

--- a/conferences/2017/ux.json
+++ b/conferences/2017/ux.json
@@ -176,7 +176,7 @@
     "url": "http://2017.kerning.it"
   },
   {
-    "name": "UXPA 2017",
+    "name": "UXPA",
     "url": "http://uxpa.github.io",
     "date": "June 5 - 8",
     "startDate": "2017-06-05",
@@ -223,7 +223,7 @@
     "url": "https://www.generateconf.com/san-francisco"
   },
   {
-    "name": "UX Strat 2017",
+    "name": "UX Strat",
     "url": "http://www.uxstrat.com/europe",
     "date": "June 15-18",
     "startDate": "2017-06-15",
@@ -239,7 +239,7 @@
     "country": "Germany"
   },
   {
-    "name": "Eyeo 2017",
+    "name": "Eyeo",
     "url": "http://eyeofestival.com",
     "date": "June 26-29",
     "startDate": "2017-06-26",
@@ -271,7 +271,7 @@
     "twitter": "@semiglobal"
   },
   {
-    "name": "MobileHCI 2017",
+    "name": "MobileHCI",
     "url": "http://mobilehci.acm.org/2017",
     "date": "Sept 4-7",
     "startDate": "2017-09-04",
@@ -583,7 +583,7 @@
     "startDate": "2017-11-09",
     "endDate": "2017-11-11",
     "twitter": "@isa17floripa",
-    "name": "Interaction South America - 2017",
+    "name": "Interaction South America",
     "url": "http://isa.ixda.org/2017"
   },
   {

--- a/conferences/2018/data.json
+++ b/conferences/2018/data.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Big Data Paris 2018",
+    "name": "Big Data Paris",
     "url": "https://www.bigdataparis.com",
     "startDate": "2018-03-12",
     "endDate": "2018-03-13",
@@ -9,7 +9,7 @@
     "twitter": "@bigdataparis"
   },
   {
-    "name": "FEniCS‘18",
+    "name": "FEniCS",
     "url": "https://fenicsproject.org/fenics18",
     "startDate": "2018-03-21",
     "endDate": "2018-03-23",
@@ -44,7 +44,7 @@
     "country": "U.S.A."
   },
   {
-    "name": "TiE Inflect 2018",
+    "name": "TiE Inflect",
     "url": "https://www.tieinflect.org",
     "startDate": "2018-05-04",
     "endDate": "2018-05-04",

--- a/conferences/2018/devops.json
+++ b/conferences/2018/devops.json
@@ -410,7 +410,7 @@
     "country": "China"
   },
   {
-    "name": "Devops 2018",
+    "name": "Devops",
     "url": "http://www.devops2018.com",
     "startDate": "2018-12-13",
     "endDate": "2018-12-14",

--- a/conferences/2018/general.json
+++ b/conferences/2018/general.json
@@ -565,7 +565,7 @@
     "twitter": "@webaudioconf"
   },
   {
-    "name": "PolarConf 2018",
+    "name": "PolarConf",
     "url": "https://www.papercall.io/polcarconf-2018",
     "startDate": "2018-10-10",
     "endDate": "2018-10-11",

--- a/conferences/2018/ruby.json
+++ b/conferences/2018/ruby.json
@@ -220,7 +220,7 @@
     "twitter": "@southeastruby"
   },
   {
-    "name": "Deccan Ruby Conf 2018",
+    "name": "Deccan Ruby Conf",
     "url": "http://www.deccanrubyconf.org",
     "startDate": "2018-08-04",
     "endDate": "2018-08-04",

--- a/conferences/2018/tech-comm.json
+++ b/conferences/2018/tech-comm.json
@@ -33,7 +33,7 @@
     "country": "U.S.A."
   },
   {
-    "name": "API the Docs Paris 2018",
+    "name": "API the Docs Paris",
     "url": "https://www.eventbrite.com/e/api-the-docs-paris-2018-tickets-42858996412?aff=es2",
     "startDate": "2018-04-24",
     "endDate": "2018-04-24",

--- a/conferences/2018/ux.json
+++ b/conferences/2018/ux.json
@@ -9,7 +9,7 @@
     "twitter": "@front"
   },
   {
-    "name": "Interaction week 18",
+    "name": "Interaction week",
     "url": "http://interaction18.ixda.org",
     "startDate": "2018-02-03",
     "endDate": "2018-02-08",
@@ -101,7 +101,7 @@
     "country": "Canada"
   },
   {
-    "name": "ACM IUI 2018",
+    "name": "ACM IUI",
     "url": "http://iui.acm.org/2018",
     "startDate": "2018-03-07",
     "endDate": "2018-03-11",
@@ -149,7 +149,7 @@
     "twitter": "@uxcitymcr"
   },
   {
-    "name": "TEI 2018",
+    "name": "TEI",
     "url": "https://tei.acm.org/2018",
     "startDate": "2018-03-18",
     "endDate": "2018-03-21",
@@ -177,7 +177,7 @@
     "twitter": "@exconfba"
   },
   {
-    "name": "CHIuXiD 2018",
+    "name": "CHIuXiD",
     "url": "http://2018.chiuxid.org",
     "startDate": "2018-03-26",
     "endDate": "2018-03-29",
@@ -219,7 +219,7 @@
     "twitter": "@smashingconf"
   },
   {
-    "name": "CHI 2018",
+    "name": "CHI",
     "url": "https://chi2018.acm.org",
     "startDate": "2018-04-21",
     "endDate": "2018-04-26",
@@ -227,7 +227,7 @@
     "country": "Canada"
   },
   {
-    "name": "Design Thinking 2018",
+    "name": "Design Thinking",
     "url": "https://designthinkingusa.iqpc.com",
     "startDate": "2018-04-23",
     "endDate": "2018-04-25",
@@ -235,7 +235,7 @@
     "country": "U.S.A."
   },
   {
-    "name": "Generate ",
+    "name": "Generate",
     "url": "https://www.generateconf.com/new-york",
     "startDate": "2018-04-25",
     "endDate": "2018-04-27",
@@ -461,7 +461,7 @@
     "country": "Canada"
   },
   {
-    "name": "UXPA 2018",
+    "name": "UXPA",
     "url": "http://uxpa2018.org",
     "startDate": "2018-06-26",
     "endDate": "2018-06-28",
@@ -491,7 +491,7 @@
     "twitter": "@addconf"
   },
   {
-    "name": "ACM UMAP 2018",
+    "name": "ACM UMAP",
     "url": "http://www.um.org/umap2018",
     "startDate": "2018-07-08",
     "endDate": "2018-07-11",
@@ -501,7 +501,7 @@
     "cfpEndDate": "2018-03-04"
   },
   {
-    "name": "UXWeek 2018",
+    "name": "UXWeek",
     "url": "http://uxweek.com",
     "startDate": "2018-08-21",
     "endDate": "2018-08-24",


### PR DESCRIPTION
Hey,

I've removed years from the conference names. If we decide to use conference names as keys one day, for example, to show the event history, the year in the name might be a problem.
What do you think? 