### PR TITLE
Changed label for the conference name

### DIFF
--- a/src/components/ConferenceNewPage/ConferenceNewPage.js
+++ b/src/components/ConferenceNewPage/ConferenceNewPage.js
@@ -428,8 +428,8 @@ export default class ConferenceNewPage extends Component {
           <p>
             Submitting a conference will create a{' '}
             <Link external url="https://github.com/tech-conferences/confs.tech/pulls">
-              pull requests  on github
-            </Link> that will be reviewed by our team in the shorthest delayed!
+              pull requests on GitHub
+            </Link> that will be reviewed by our team as soon as possible!
           </p>
         }
         {submitted ? this.submitted() : this.form()}

--- a/src/components/ConferenceNewPage/ConferenceNewPage.js
+++ b/src/components/ConferenceNewPage/ConferenceNewPage.js
@@ -234,7 +234,7 @@ export default class ConferenceNewPage extends Component {
           </InputGroup>
           <InputGroup>
             <div>
-              <label htmlFor="name">Name</label>
+              <label htmlFor="name">Conference name</label>
               <input
                 className={classNames(
                   this.hasError('name') && styles.error


### PR DESCRIPTION
A couple of times people added their name instead of the conference name in the Add conference form. I've changed the label for the input with the conference name.