### PR TITLE
Enabled IP anonymization in Google Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-105233299-1', 'auto');
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
   </head>


### PR DESCRIPTION
I've enabled the IP anonymization in our Google Analytics script - full IPs of users won't be sent to Google. As far as I know it should not affect the accuracy of geo reporting significantly. 
More about P anonymization: https://support.google.com/analytics/answer/2763052