### PR TITLE
Better color ratios

### DIFF
--- a/src/components/ConferencePage/CurrentRefinement.scss
+++ b/src/components/ConferencePage/CurrentRefinement.scss
@@ -49,7 +49,7 @@
   width: 15px;
   padding: 0;
   font-size: 9px;
-  color: color(gray, lighter);
+  color: color(gray, darker);
   transition: all 100ms linear;
 }
 

--- a/src/components/ConferencePage/RefinementList.scss
+++ b/src/components/ConferencePage/RefinementList.scss
@@ -38,7 +38,7 @@
 :global(.ais-RefinementList__itemCount) {
   border-radius: 30px;
   background-color: color(gray, lighter);
-  color: color(accent);
+  color: color(accent, dark);
   font-size: font-size(filter, itemCount);
   padding: 0 6px;
 }

--- a/src/components/style/foundation/_colors.scss
+++ b/src/components/style/foundation/_colors.scss
@@ -4,7 +4,8 @@
 // stylelint-disable color-no-hex, no-indistinguishable-colors, function-max-empty-lines, value-list-max-empty-lines
 $color-palette-data: (
   accent: (
-    base: #53ACFE,
+    dark: #0a6cc6,
+    base: #0b76d8,
   ),
   accent-2: (
     base: #FFCA04,
@@ -13,8 +14,9 @@ $color-palette-data: (
     base: #4caf50,
   ),
   gray: (
+    darker: #000,
     dark: #555555,
-    base: #888888,
+    base: #777676,
     light: #CCCCCC,
     lighter: #EEEEEE,
   )

--- a/src/components/style/foundation/_colors.scss
+++ b/src/components/style/foundation/_colors.scss
@@ -14,7 +14,7 @@ $color-palette-data: (
     base: #4caf50,
   ),
   gray: (
-    darker: #000,
+    darker: #000000,
     dark: #555555,
     base: #777676,
     light: #CCCCCC,


### PR DESCRIPTION
In an effort to make the website more accessible, every text and link color should have a ratio of `4.5:1` if we want to follow the [WCAG AA guideline](https://www.w3.org/TR/WCAG20-TECHS/G18.html).

The blue was pretty light but I tried to mimic the original color as most as possible. 

I adjusted some colors value and added two new keys `accent, dark` and `gray, darker`.

You can check the `ratio` directly in Chrome Devtools if you click directly on the color thumbnail. Exemple : 

<img width="594" alt="screen shot 2018-05-08 at 6 18 16 pm" src="https://user-images.githubusercontent.com/6691035/39785949-35b5ae42-52ec-11e8-941a-41dd54ec8481.png">
