### PR TITLE
Add Node.js v10.x in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,5 +124,8 @@
   },
   "eslintConfig": {
     "extends": "react-app"
+  },
+  "engines": {
+    "node": "10.x"
   }
 }


### PR DESCRIPTION
Heroku documentation https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
Node.js v10.x is supported https://devcenter.heroku.com/articles/nodejs-support#supported-runtimes