### PR TITLE
Fix Conference Item Accessibility

### DIFF
--- a/src/components/ConferenceItem/ConferenceItem.js
+++ b/src/components/ConferenceItem/ConferenceItem.js
@@ -38,22 +38,25 @@ export default class ConferenceItem extends PureComponent {
             {name}
           </Link>
         </Heading>
-        <dl>
+        <dl className={styles.dl}>
           <div>
             <dt className="visuallyHidden">Location</dt>
-            <dd className={classNames(styles.p, styles.dd)}>
+            <dd>
               {`${Location(city, country)}`}
             </dd>
+          </div>
+          <div>
             <dt className="visuallyHidden">Date</dt>
-            <dd className={classNames(styles.Date, styles.dd)}>
-              {formatDate(startDate, endDate)}
+            <dd>
+              <span aria-hidden="true">・</span>{formatDate(startDate, endDate)}
             </dd>
           </div>
           {showCFP && <Cfp url={cfpUrl || url} date={cfpEndDate} />}
           {showCFP && <br />}
-          <div className={classNames(styles.p, styles.Footer)}>
+          <div className={styles.Footer}>
             <Topics topics={topics} />
-            {twitter && ' – '}
+          </div>
+          <div className={styles.Footer}>
             <Twitter twitter={twitter} />
           </div>
         </dl>
@@ -68,7 +71,8 @@ function Twitter({twitter}) {
   return (
     <React.Fragment>
       <dt className="visuallyHidden">Twitter username</dt>
-      <dd className={styles.dd}>
+      <dd>
+        <span className={styles.seperator} aria-hidden="true"> – </span>
         <Link url={`https://twitter.com/${twitter}`} external>
           {twitter}
         </Link>
@@ -89,7 +93,7 @@ function Cfp({url, date}) {
   return (
     <React.Fragment>
       <dt className="visuallyHidden">Call for proposal</dt>
-      <dd className={styles.dd}>
+      <dd>
         <Link url={url} external className={styles.cfp}>
           CFP closes {formatDate(parse(date))}
         </Link>
@@ -100,12 +104,12 @@ function Cfp({url, date}) {
 
 
 function Topics({topics}) {
-  const topicsList = topics.map((topic) => <li key={topic}>{topic}</li>);
+  const topicsList = topics.map((topic) => <li key={topic} className={styles.topic}><span aria-hidden="true">#</span>{topic}</li>);
 
   return (
     <React.Fragment>
       <dt className="visuallyHidden">Topics</dt>
-      <dd className={styles.dd}>
+      <dd>
         <ul className={styles.topics}>
           {topicsList}
         </ul>

--- a/src/components/ConferenceItem/ConferenceItem.js
+++ b/src/components/ConferenceItem/ConferenceItem.js
@@ -24,7 +24,7 @@ export default class ConferenceItem extends PureComponent {
     } = this.props;
 
     return (
-      <div
+      <li
         className={classNames(
           styles.ConferenceItem
         )}
@@ -38,20 +38,26 @@ export default class ConferenceItem extends PureComponent {
             {name}
           </Link>
         </Heading>
-        <p className={styles.p}>
-          {`${Location(city, country)}・`}
-          <span className={styles.Date}>
-            {formatDate(startDate, endDate)}
-          </span>
-        </p>
-        <p className={classNames(styles.p, styles.Footer)}>
+        <dl>
+          <div>
+            <dt className="visuallyHidden">Location</dt>
+            <dd className={classNames(styles.p, styles.dd)}>
+              {`${Location(city, country)}`}
+            </dd>
+            <dt className="visuallyHidden">Date</dt>
+            <dd className={classNames(styles.Date, styles.dd)}>
+              {formatDate(startDate, endDate)}
+            </dd>
+          </div>
           {showCFP && <Cfp url={cfpUrl || url} date={cfpEndDate} />}
           {showCFP && <br />}
-          <Topics topics={topics} />
-          {twitter && ' – '}
-          <Twitter twitter={twitter} />
-        </p>
-      </div>
+          <div className={classNames(styles.p, styles.Footer)}>
+            <Topics topics={topics} />
+            {twitter && ' – '}
+            <Twitter twitter={twitter} />
+          </div>
+        </dl>
+      </li>
     );
   }
 }
@@ -60,9 +66,14 @@ function Twitter({twitter}) {
   if (!twitter) { return null; }
 
   return (
-    <Link url={`https://twitter.com/${twitter}`} external>
-      {twitter}
-    </Link>
+    <React.Fragment>
+      <dt className="visuallyHidden">Twitter username</dt>
+      <dd className={styles.dd}>
+        <Link url={`https://twitter.com/${twitter}`} external>
+          {twitter}
+        </Link>
+      </dd>
+    </React.Fragment>
   );
 }
 
@@ -76,13 +87,29 @@ function Location(city, country) {
 
 function Cfp({url, date}) {
   return (
-    <Link url={url} external className={styles.cfp}>
-      CFP closes {formatDate(parse(date))}
-    </Link>
+    <React.Fragment>
+      <dt className="visuallyHidden">Call for proposal</dt>
+      <dd className={styles.dd}>
+        <Link url={url} external className={styles.cfp}>
+          CFP closes {formatDate(parse(date))}
+        </Link>
+      </dd>
+    </React.Fragment>
   );
 }
 
 
 function Topics({topics}) {
-  return topics.map((topic) => `#${topic}`).join(' ');
+  const topicsList = topics.map((topic) => <li key={topic}>{topic}</li>);
+
+  return (
+    <React.Fragment>
+      <dt className="visuallyHidden">Topics</dt>
+      <dd className={styles.dd}>
+        <ul className={styles.topics}>
+          {topicsList}
+        </ul>
+      </dd>
+    </React.Fragment>
+  );
 }

--- a/src/components/ConferenceItem/ConferenceItem.js
+++ b/src/components/ConferenceItem/ConferenceItem.js
@@ -51,9 +51,10 @@ export default class ConferenceItem extends PureComponent {
               <span aria-hidden="true">・</span>{formatDate(startDate, endDate)}
             </dd>
           </div>
-          {showCFP && <Cfp url={cfpUrl || url} date={cfpEndDate} />}
-          {showCFP && <br />}
-          <div className={styles.Footer}>
+          <div className={classNames(styles.cfp, styles.Footer)}>
+            {showCFP && <Cfp url={cfpUrl || url} date={cfpEndDate} />}
+          </div>
+          <div className={classNames(styles.topicsList, styles.Footer)}>
             <Topics topics={topics} />
           </div>
           <div className={styles.Footer}>
@@ -92,7 +93,7 @@ function Location(city, country) {
 function Cfp({url, date}) {
   return (
     <React.Fragment>
-      <dt className="visuallyHidden">Call for proposal</dt>
+      <dt className="visuallyHidden">Call for papers</dt>
       <dd>
         <Link url={url} external className={styles.cfp}>
           CFP closes {formatDate(parse(date))}

--- a/src/components/ConferenceItem/ConferenceItem.scss
+++ b/src/components/ConferenceItem/ConferenceItem.scss
@@ -5,19 +5,30 @@
   margin-bottom: spacing(base);
 }
 
-.Date {
-  margin-right: spacing(tight);
-}
-
-.p {
+.dl {
   margin: 0;
-  line-height: 1.5em;
+  line-height: 1.5;
+  &::after {
+    content: "";
+    clear: both;
+    display: table;
+  }
+
+  div {
+    float: left;
+    &:nth-child(3) {
+      clear: left;
+    }
+  }
+  dd {
+    margin-left: 0;
+  }
 }
 
-.dd {
-  margin-left: 0;
+.seperator {
+  display: inline-block;
+  margin: 0 spacing(extra-tight);
 }
-
 .Footer,
 .Footer a {
   font-weight: 200;
@@ -28,9 +39,13 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
 }
 
 .topic {
   margin-right: spacing(extra-tight);
   vertical-align: middle;
+  &:last-child {
+    margin-right: 0;
+  }
 }

--- a/src/components/ConferenceItem/ConferenceItem.scss
+++ b/src/components/ConferenceItem/ConferenceItem.scss
@@ -16,9 +16,6 @@
 
   div {
     float: left;
-    &:nth-child(3) {
-      clear: left;
-    }
   }
   dd {
     margin-left: 0;
@@ -29,10 +26,19 @@
   display: inline-block;
   margin: 0 spacing(extra-tight);
 }
+
+.cfp {
+  clear: left;
+}
+
 .Footer,
 .Footer a {
   font-weight: 200;
   color: color(gray);
+}
+
+.topicsList {
+  clear: left;
 }
 
 .topics {

--- a/src/components/ConferenceItem/ConferenceItem.scss
+++ b/src/components/ConferenceItem/ConferenceItem.scss
@@ -14,10 +14,20 @@
   line-height: 1.5em;
 }
 
+.dd {
+  margin-left: 0;
+}
+
 .Footer,
 .Footer a {
   font-weight: 200;
   color: color(gray);
+}
+
+.topics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .topic {

--- a/src/components/ConferenceList/ConferenceList.css
+++ b/src/components/ConferenceList/ConferenceList.css
@@ -3,6 +3,11 @@
 
 .ConferenceList {
   width: 100%;
+
+  ul {
+    list-style: none;
+    padding: 0;
+  }
 }
 
 .Year {

--- a/src/components/ConferenceList/ConferenceList.js
+++ b/src/components/ConferenceList/ConferenceList.js
@@ -86,19 +86,21 @@ function getMonthName(month) {
 }
 
 function Months({month, conferences, showCFP}) {
+  const months = conferences.map((conf) => {
+    return (
+      <ConferenceItem
+        {...conf}
+        key={conf.objectID}
+        showCFP={showCFP}
+      />
+    );
+  });
+
   return [
     <Heading key={month} element="h2" level={3}>
       {getMonthName(month)}
     </Heading>,
-    conferences.map((conf) => {
-      return (
-        <ConferenceItem
-          {...conf}
-          key={conf.objectID}
-          showCFP={showCFP}
-        />
-      );
-    }),
+    <ul key={month}>{months}</ul>,
   ];
 }
 

--- a/src/components/ConferencePage/CurrentRefinement.scss
+++ b/src/components/ConferencePage/CurrentRefinement.scss
@@ -49,7 +49,7 @@
   width: 15px;
   padding: 0;
   font-size: 9px;
-  color: color(gray, lighter);
+  color: color(gray, darker);
   transition: all 100ms linear;
 }
 

--- a/src/components/ConferencePage/RefinementList.scss
+++ b/src/components/ConferencePage/RefinementList.scss
@@ -38,7 +38,7 @@
 :global(.ais-RefinementList__itemCount) {
   border-radius: 30px;
   background-color: color(gray, lighter);
-  color: color(accent);
+  color: color(accent, dark);
   font-size: font-size(filter, itemCount);
   padding: 0 6px;
 }

--- a/src/components/style/foundation/_colors.scss
+++ b/src/components/style/foundation/_colors.scss
@@ -4,7 +4,8 @@
 // stylelint-disable color-no-hex, no-indistinguishable-colors, function-max-empty-lines, value-list-max-empty-lines
 $color-palette-data: (
   accent: (
-    base: #53ACFE,
+    dark: #0a6cc6,
+    base: #0b76d8,
   ),
   accent-2: (
     base: #FFCA04,
@@ -13,8 +14,9 @@ $color-palette-data: (
     base: #4caf50,
   ),
   gray: (
+    darker: #000,
     dark: #555555,
-    base: #888888,
+    base: #777676,
     light: #CCCCCC,
     lighter: #EEEEEE,
   )

--- a/src/components/style/foundation/_colors.scss
+++ b/src/components/style/foundation/_colors.scss
@@ -14,7 +14,7 @@ $color-palette-data: (
     base: #4caf50,
   ),
   gray: (
-    darker: #000,
+    darker: #000000,
     dark: #555555,
     base: #777676,
     light: #CCCCCC,


### PR DESCRIPTION
Continuing the effort on making the website more accessible for everyone.

### Component worked on
<img width="321" alt="screen shot 2018-05-11 at 3 13 32 pm" src="https://user-images.githubusercontent.com/6691035/39942612-fa10b960-552d-11e8-8b41-4655ad8443c4.png">

I mainly reworked the HTML structure to swap `<div>` with the right semantic HTML tags `<dl>`

--- 

#### Before, if you were navigating with a keyboard, the screen reader would read something like : 

- !! con
- New York, NY, U.S.A, *middle dot* May, 12-13th (in one long sentence)
- *number* general *minus* link, @bangbangcon

#### Now it reads like this : 
- !! con
- Location, New York, NY, U.S.A
- Date, May, 12-13th
- Topics, General
- Twitter handle, @bangbangcon

---

I added a wrapper `<ul>` for each months, that way a screen reader will announce something along the lines of "List of X items" - so the user can navigate easier and knows how many conference is coming.