### PR TITLE
Update css-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "classnames": "^2.2.5",
-    "css-loader": "0.28.4",
+    "css-loader": "^0.28.11",
     "date-fns": "^1.28.5",
     "dotenv": "4.0.0",
     "eslint": "4.18.0",


### PR DESCRIPTION
Recommendation from running `npm audit` because of critical vulnerability:

```
# Run  npm install css-loader@0.28.11  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ macaddress                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ css-loader                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ css-loader > cssnano > postcss-filter-plugins > uniqid >     │
│               │ macaddress                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/654                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```