### PR TITLE
Update RubyConf Kenya 2018

### DIFF
--- a/conferences/2018/ruby.json
+++ b/conferences/2018/ruby.json
@@ -188,7 +188,7 @@
     "name": "RubyConf Kenya",
     "url": "http://rubyconf.nairuby.org/2018",
     "startDate": "2018-06-28",
-    "endDate": "2018-06-28",
+    "endDate": "2018-06-30",
     "city": "Nairobi",
     "country": "Kenya",
     "twitter": "@nairubyke"

--- a/conferences/2018/ruby.json
+++ b/conferences/2018/ruby.json
@@ -185,9 +185,10 @@
     "twitter": "@saintprug"
   },
   {
-    "name": "Ruby Conf Kenya",
+    "name": "RubyConf Kenya",
     "url": "http://rubyconf.nairuby.org/2018",
-    "startDate": "2018-06-22",
+    "startDate": "2018-06-28",
+    "endDate": "2018-06-28",
     "city": "Nairobi",
     "country": "Kenya",
     "twitter": "@nairubyke"


### PR DESCRIPTION
Fixed name ( RubyConf instead of Ruby Conf) as all others RubyConf conferences are written in the same way.
Also added correct start and end dates.