### PR TITLE
Fix date format in older conferences

### DIFF
--- a/conferences/2014/ruby.json
+++ b/conferences/2014/ruby.json
@@ -2,7 +2,8 @@
   {
     "name": "RubyConf",
     "url": "http://rubyconf.org",
-    "date": "November 17-19, 2014",
+    "startDate": "2014-11-17",
+    "endDate": "2014-11-19",
     "city": "San Diego",
     "country": "CA",
     "twitter": "https://twitter.com/rubyconf"
@@ -10,7 +11,8 @@
   {
     "name": "RubyWorld Conference",
     "url": "http://www.rubyworld-conf.org",
-    "date": "November 13-14, 2014",
+    "startDate": "2014-11-13",
+    "endDate": "2014-11-14",
     "city": "Matsue",
     "country": "Japan",
     "twitter": "https://twitter.com/rubyworldconf"
@@ -18,7 +20,8 @@
   {
     "name": "RailsIsrael",
     "url": "http://railsisrael2014.events.co.il",
-    "date": "November 4-5, 2014",
+    "startDate": "2014-11-04",
+    "endDate": "2014-11-05",
     "city": "Tel Aviv",
     "country": "Israel",
     "twitter": "https://twitter.com/fogelmania"
@@ -26,7 +29,8 @@
   {
     "name": "RubyConf Argentina",
     "url": "http://rubyconfargentina.org",
-    "date": "October 24-25, 2014",
+    "startDate": "2014-10-24",
+    "endDate": "2014-10-25",
     "city": "Buenos Aires",
     "country": "Argentina",
     "twitter": "https://twitter.com/rubyconfar"
@@ -34,7 +38,8 @@
   {
     "name": "Keep Ruby Weird",
     "url": "http://keeprubyweird.com",
-    "date": "October 24, 2014",
+    "startDate": "2014-10-24",
+    "endDate": "2014-10-24",
     "city": "Austin",
     "country": "TX",
     "twitter": "https://twitter.com/keeprubyweird"
@@ -42,7 +47,8 @@
   {
     "name": "RubyConf Portugal",
     "url": "http://rubyconf.pt",
-    "date": "October 13-14, 2014",
+    "startDate": "2014-10-13",
+    "endDate": "2014-10-14",
     "city": "Braga",
     "country": "Portugal",
     "twitter": "https://twitter.com/rubyconfpt"
@@ -50,7 +56,8 @@
   {
     "name": "Ruby DCamp",
     "url": "http://rubydcamp.org",
-    "date": "October 10-12, 2014",
+    "startDate": "2014-10-10",
+    "endDate": "2014-10-12",
     "city": "Prince William Forest Park",
     "country": "VA",
     "twitter": "https://twitter.com/ruby_dcamp"
@@ -58,7 +65,8 @@
   {
     "name": "Nickel City Ruby Conference",
     "url": "http://nickelcityruby.com",
-    "date": "October 3-4, 2014",
+    "startDate": "2014-10-03",
+    "endDate": "2014-10-04",
     "city": "Buffalo",
     "country": "NY",
     "twitter": "https://twitter.com/nickelcityruby"
@@ -66,7 +74,8 @@
   {
     "name": "ArrrrCamp",
     "url": "http://arrrrcamp.be",
-    "date": "October 2-3, 2014",
+    "startDate": "2014-10-02",
+    "endDate": "2014-10-03",
     "city": "Ghent",
     "country": "Belgium",
     "twitter": "https://twitter.com/arrrrcamp"
@@ -74,7 +83,8 @@
   {
     "name": "RailsClub",
     "url": "http://railsclub.ru",
-    "date": "September 27, 2014",
+    "startDate": "2014-09-27",
+    "endDate": "2014-09-27",
     "city": "Moscow",
     "country": "Russia",
     "twitter": "https://twitter.com/railsclub_ru"
@@ -82,7 +92,8 @@
   {
     "name": "Rails Pacific",
     "url": "http://www.railspacific.com",
-    "date": "September 26-27, 2014",
+    "startDate": "2014-09-26",
+    "endDate": "2014-09-27",
     "city": "Taipei",
     "country": "Taiwan",
     "twitter": "https://twitter.com/railspacific"
@@ -90,14 +101,16 @@
   {
     "name": "Rocky Mountain Ruby Conference",
     "url": "http://rockymtnruby.com",
-    "date": "September 25-26, 2014",
+    "startDate": "2014-09-25",
+    "endDate": "2014-09-26",
     "city": "Boulder",
     "country": "CO",
     "twitter": "https://twitter.com/rockymtnruby"
   },
   {
     "name": "Golden Gate Ruby Conference",
-    "date": "September 19-20, 2014",
+    "startDate": "2014-09-19",
+    "endDate": "2014-09-20",
     "city": "San Francisco",
     "country": "CA",
     "twitter": "https://twitter.com/gogaruco"
@@ -105,7 +118,8 @@
   {
     "name": "RubyKaigi",
     "url": "http://rubykaigi.org",
-    "date": "September 18-20, 2014",
+    "startDate": "2014-09-18",
+    "endDate": "2014-09-20",
     "city": "Tokyo",
     "country": "Japan",
     "twitter": "https://twitter.com/rubykaigi"
@@ -113,7 +127,8 @@
   {
     "name": "Barcelona Ruby Conf",
     "url": "http://www.baruco.org",
-    "date": "September 11-13, 2014",
+    "startDate": "2014-09-11",
+    "endDate": "2014-09-13",
     "city": "Barcelona",
     "country": "Spain",
     "twitter": "https://twitter.com/baruco"
@@ -121,7 +136,8 @@
   {
     "name": "Frozen Rails",
     "url": "http://frozenrails.eu",
-    "date": "September 11-12, 2014",
+    "startDate": "2014-09-11",
+    "endDate": "2014-09-12",
     "city": "Helsinki",
     "country": "Finland",
     "twitter": "https://twitter.com/frozenrails"
@@ -129,7 +145,8 @@
   {
     "name": "WindyCityRails",
     "url": "http://www.windycityrails.org",
-    "date": "September 4-5, 2014",
+    "startDate": "2014-09-04",
+    "endDate": "2014-09-05",
     "city": "Chicago",
     "country": "IL",
     "twitter": "https://twitter.com/windycityrails"
@@ -137,7 +154,8 @@
   {
     "name": "RubyConf Brazil",
     "url": "http://www.rubyconf.com.br",
-    "date": "August 28-29, 2014",
+    "startDate": "2014-08-28",
+    "endDate": "2014-08-29",
     "city": "São Paulo",
     "country": "Brazil",
     "twitter": "https://twitter.com/rubyconfbr"
@@ -145,7 +163,8 @@
   {
     "name": "RedFrogConf",
     "url": "http://ruby.froscon.org",
-    "date": "August 23-24, 2014",
+    "startDate": "2014-08-23",
+    "endDate": "2014-08-24",
     "city": "Sankt Augustin",
     "country": "Germany",
     "twitter": "https://twitter.com/redfrogconf"
@@ -153,7 +172,8 @@
   {
     "name": "Madison+ Ruby",
     "url": "http://madisonpl.us/ruby",
-    "date": "August 22-23, 2014",
+    "startDate": "2014-08-22",
+    "endDate": "2014-08-23",
     "city": "Madison",
     "country": "WI",
     "twitter": "https://twitter.com/madisonruby"
@@ -161,7 +181,8 @@
   {
     "name": "Cascadia Ruby",
     "url": "http://cascadiaruby.com",
-    "date": "August 11-12, 2014",
+    "startDate": "2014-08-11",
+    "endDate": "2014-08-12",
     "city": "Portland",
     "country": "OR",
     "twitter": "https://twitter.com/cascadiaruby"
@@ -169,7 +190,8 @@
   {
     "name": "JRubyConf EU",
     "url": "http://jrubyconf.eu",
-    "date": "August 1, 2014",
+    "startDate": "2014-08-01",
+    "endDate": "2014-08-01",
     "city": "Potsdam",
     "country": "Germany",
     "twitter": "https://twitter.com/jrubyconfeu"
@@ -177,7 +199,8 @@
   {
     "name": "eurucamp",
     "url": "http://2014.eurucamp.org",
-    "date": "August 1-3, 2014",
+    "startDate": "2014-08-01",
+    "endDate": "2014-08-03",
     "city": "Potsdam",
     "country": "Germany",
     "twitter": "https://twitter.com/eurucamp"
@@ -185,7 +208,8 @@
   {
     "name": "Burlington Ruby Conference",
     "url": "http://burlingtonruby.github.io/conference",
-    "date": "August 1-3, 2014",
+    "startDate": "2014-08-01",
+    "endDate": "2014-08-03",
     "city": "Burlington",
     "country": "VT",
     "twitter": "https://twitter.com/btvrubyconf"
@@ -193,7 +217,8 @@
   {
     "name": "Brighton Ruby Conf",
     "url": "http://brightonruby.com",
-    "date": "July 21, 2014",
+    "startDate": "2014-07-21",
+    "endDate": "2014-07-21",
     "city": "Brighton",
     "country": "U.K.",
     "twitter": "https://twitter.com/brightonruby"
@@ -201,7 +226,8 @@
   {
     "name": "Deccan Ruby Conference",
     "url": "http://www.deccanrubyconf.org",
-    "date": "July 19, 2014",
+    "startDate": "2014-07-19",
+    "endDate": "2014-07-19",
     "city": "Pune",
     "country": "India",
     "twitter": "https://twitter.com/deccanrubyconf"
@@ -209,14 +235,16 @@
   {
     "name": "RedDotRubyConf",
     "url": "http://reddotrubyconf.com",
-    "date": "June 26-27, 2014",
+    "startDate": "2014-06-26",
+    "endDate": "2014-06-27",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
   {
     "name": "Gotham Ruby Conference",
     "url": "http://goruco.com",
-    "date": "June 21, 2014",
+    "startDate": "2014-06-21",
+    "endDate": "2014-06-21",
     "city": "New York",
     "country": "NY",
     "twitter": "https://twitter.com/goruco"
@@ -224,7 +252,8 @@
   {
     "name": "Ruby Lugdunum",
     "url": "http://rulu.eu",
-    "date": "June 19-20, 2014",
+    "startDate": "2014-06-19",
+    "endDate": "2014-06-20",
     "city": "Lyon",
     "country": "France",
     "twitter": "https://twitter.com/rulu"
@@ -232,7 +261,8 @@
   {
     "name": "RubyNation",
     "url": "http://www.rubynation.org",
-    "date": "June 6-7, 2014",
+    "startDate": "2014-06-06",
+    "endDate": "2014-06-07",
     "city": "Washington",
     "country": "DC",
     "twitter": "https://twitter.com/rubynation"
@@ -240,7 +270,8 @@
   {
     "name": "Ruby Conference Kiev",
     "url": "http://rubyc.eu",
-    "date": "May 31-June 1, 2014",
+    "startDate": "2014-05-31",
+    "endDate": "2014-06-01",
     "city": "Kiev",
     "country": "Ukraine",
     "twitter": "https://twitter.com/rubyc_eu"
@@ -248,14 +279,16 @@
   {
     "name": "RubyMotion #inspect",
     "url": "http://www.rubymotion.com/conference/2014",
-    "date": "May 28-29, 2014",
+    "startDate": "2014-05-28",
+    "endDate": "2014-05-29",
     "city": "San Francisco",
     "country": "CA",
     "twitter": "https://twitter.com/rubymotion"
   },
   {
     "name": "RubyConf Uruguay",
-    "date": "May 23-24, 2014",
+    "startDate": "2014-05-23",
+    "endDate": "2014-05-24",
     "city": "Montevideo",
     "country": "Uruguay",
     "twitter": "https://twitter.com/rubyconfuruguay"
@@ -263,7 +296,8 @@
   {
     "name": "Scottish Ruby Conf",
     "url": "http://scottishrubyconference.com",
-    "date": "May 12-13, 2014",
+    "startDate": "2014-05-12",
+    "endDate": "2014-05-13",
     "city": "Perthshire",
     "country": "Scotland",
     "twitter": "https://twitter.com/scotrubyconf"
@@ -271,7 +305,8 @@
   {
     "name": "RubyConf Taiwan",
     "url": "http://rubyconf.tw",
-    "date": "April 25-26, 2014",
+    "startDate": "2014-04-25",
+    "endDate": "2014-04-26",
     "city": "Taipei",
     "country": "Taiwan",
     "twitter": "https://twitter.com/rubytaiwan"
@@ -279,7 +314,8 @@
   {
     "name": "Abril Pro Ruby",
     "url": "http://abrilproruby.com",
-    "date": "April 24-27, 2014",
+    "startDate": "2014-04-24",
+    "endDate": "2014-04-27",
     "city": "Porto de Galinhas",
     "country": "Brazil",
     "twitter": "https://twitter.com/abrilproruby"
@@ -287,7 +323,8 @@
   {
     "name": "RailsConf",
     "url": "http://www.railsconf.com",
-    "date": "April 22-25, 2014",
+    "startDate": "2014-04-22",
+    "endDate": "2014-04-25",
     "city": "Chicago",
     "country": "IL",
     "twitter": "https://twitter.com/railsconf"
@@ -295,7 +332,8 @@
   {
     "name": "Ancient City Ruby",
     "url": "http://www.ancientcityruby.com",
-    "date": "April 3-4, 2014",
+    "startDate": "2014-04-03",
+    "endDate": "2014-04-04",
     "city": "St. Augustine",
     "country": "FL",
     "twitter": "https://twitter.com/ancientcityruby"
@@ -303,7 +341,8 @@
   {
     "name": "RubyConf Philippines",
     "url": "http://rubyconf.ph",
-    "date": "March 28-29, 2014",
+    "startDate": "2014-03-28",
+    "endDate": "2014-03-29",
     "city": "Manila",
     "country": "Philippines",
     "twitter": "https://twitter.com/rubyconfph"
@@ -311,7 +350,8 @@
   {
     "name": "RubyConf India",
     "url": "http://rubyconfindia.org",
-    "date": "March 22-23, 2014",
+    "startDate": "2014-03-22",
+    "endDate": "2014-03-23",
     "city": "Goa",
     "country": "India",
     "twitter": "https://twitter.com/rubyconfindia"
@@ -319,7 +359,8 @@
   {
     "name": "MountainWest RubyConf",
     "url": "http://mtnwestrubyconf.org",
-    "date": "March 20-21, 2014",
+    "startDate": "2014-03-20",
+    "endDate": "2014-03-21",
     "city": "Salt Lake City",
     "country": "UT",
     "twitter": "https://twitter.com/mwrc"
@@ -327,28 +368,32 @@
   {
     "name": "wroc_love.rb",
     "url": "http://wrocloverb.com",
-    "date": "March 14-16, 2014",
+    "startDate": "2014-03-14",
+    "endDate": "2014-03-16",
     "city": "Wrocław",
     "country": "Poland",
     "twitter": "https://twitter.com/wrocloverb"
   },
   {
     "name": "Ruby on Ales",
-    "date": "March 6-7, 2014",
+    "startDate": "2014-03-06",
+    "endDate": "2014-03-07",
     "city": "Bend",
     "country": "OR",
     "twitter": "https://twitter.com/rbonales"
   },
   {
     "name": "RubySauna",
-    "date": "February 27, 2014",
+    "startDate": "2014-02-27",
+    "endDate": "2014-02-27",
     "city": "Oulu",
     "country": "Finland",
     "twitter": "https://twitter.com/rubysauna"
   },
   {
     "name": "Big Ruby",
-    "date": "February 20-21, 2014",
+    "startDate": "2014-02-20",
+    "endDate": "2014-02-21",
     "city": "Dallas",
     "country": "TX",
     "twitter": "https://twitter.com/bigrubyconf"
@@ -356,14 +401,16 @@
   {
     "name": "Ruby Conf Australia",
     "url": "http://www.rubyconf.org.au",
-    "date": "February 20-21, 2014",
+    "startDate": "2014-02-20",
+    "endDate": "2014-02-21",
     "city": "Sydney",
     "country": "Australia",
     "twitter": "https://twitter.com/rubyconf_au"
   },
   {
     "name": "Los Angeles Ruby Conference",
-    "date": "February 8, 2014",
+    "startDate": "2014-02-08",
+    "endDate": "2014-02-08",
     "city": "Los Angeles",
     "country": "CA",
     "twitter": "https://twitter.com/larubyconf"
@@ -371,7 +418,8 @@
   {
     "name": "Rubyfuza",
     "url": "http://rubyfuza.org",
-    "date": "February 6-8, 2014",
+    "startDate": "2014-02-06",
+    "endDate": "2014-02-08",
     "city": "Cape Town",
     "country": "South Africa",
     "twitter": "https://twitter.com/rubyfuza"
@@ -379,7 +427,8 @@
   {
     "name": "Garden City RubyConf",
     "url": "http://www.gardencityruby.org",
-    "date": "January 3-4, 2014",
+    "startDate": "2014-01-03",
+    "endDate": "2014-01-04",
     "city": "Bangalore",
     "country": "India",
     "twitter": "https://twitter.com/gardencityrb"

--- a/conferences/2015/ruby.json
+++ b/conferences/2015/ruby.json
@@ -2,7 +2,8 @@
   {
     "name": "RubyKaigi",
     "url": "http://rubykaigi.org/2015",
-    "date": "December 11-13, 2015",
+    "startDate": "2015-12-11",
+    "endDate": "2015-12-13",
     "city": "Tokyo",
     "country": "Japan",
     "twitter": "https://twitter.com/rubykaigi"
@@ -10,7 +11,8 @@
   {
     "name": "RailsIsrael",
     "url": "http://railsisrael2015.events.co.il",
-    "date": "November 24, 2015",
+    "startDate": "2015-11-24",
+    "endDate": "2015-11-24",
     "city": "Tel Aviv",
     "country": "Israel",
     "twitter": "https://twitter.com/railsisrael"
@@ -18,7 +20,8 @@
   {
     "name": "RubyConf",
     "url": "http://rubyconf.org",
-    "date": "November 15-17, 2015",
+    "startDate": "2015-11-15",
+    "endDate": "2015-11-17",
     "city": "San Antonio",
     "country": "TX",
     "twitter": "https://twitter.com/rubyconf"
@@ -26,7 +29,8 @@
   {
     "name": "RubyDay",
     "url": "http://www.rubyday.it",
-    "date": "November 13, 2015",
+    "startDate": "2015-11-13",
+    "endDate": "2015-11-13",
     "city": "Turin",
     "country": "Italy",
     "twitter": "https://twitter.com/rubydayit"
@@ -34,7 +38,8 @@
   {
     "name": "RubyWorld Conference",
     "url": "http://www.rubyworld-conf.org",
-    "date": "November 11-12, 2015",
+    "startDate": "2015-11-11",
+    "endDate": "2015-11-12",
     "city": "Matsue",
     "country": "Japan",
     "twitter": "https://twitter.com/rubyworldconf"
@@ -42,7 +47,8 @@
   {
     "name": "Keep Ruby Weird",
     "url": "http://keeprubyweird.com",
-    "date": "October 23, 2015",
+    "startDate": "2015-10-23",
+    "endDate": "2015-10-23",
     "city": "Austin",
     "country": "Texas",
     "twitter": "https://twitter.com/keeprubyweird"
@@ -50,7 +56,8 @@
   {
     "name": "EuRuKo",
     "url": "http://www.euruko2015.org",
-    "date": "October 17-18, 2015",
+    "startDate": "2015-10-17",
+    "endDate": "2015-10-18",
     "city": "Salzburg",
     "country": "Austria",
     "twitter": "https://twitter.com/euruko"
@@ -58,14 +65,16 @@
   {
     "name": "RubyConf Colombia",
     "url": "http://www.rubyconf.co",
-    "date": "October 15-16, 2015",
+    "startDate": "2015-10-15",
+    "endDate": "2015-10-16",
     "city": "Medellin",
     "country": "Colombia",
     "twitter": "https://twitter.com/rubyconfco"
   },
   {
     "name": "Los Angeles Ruby Conference",
-    "date": "October 10, 2015",
+    "startDate": "2015-10-10",
+    "endDate": "2015-10-10",
     "city": "Los Angeles",
     "country": "CA",
     "twitter": "https://twitter.com/larubyconf"
@@ -73,7 +82,8 @@
   {
     "name": "ArrrrCamp",
     "url": "http://2015.arrrrcamp.be",
-    "date": "October 1-2, 2015",
+    "startDate": "2015-10-01",
+    "endDate": "2015-10-02",
     "city": "Ghent",
     "country": "Belgium",
     "twitter": "https://twitter.com/arrrrcamp"
@@ -81,7 +91,8 @@
   {
     "name": "ROSSConf Berlin",
     "url": "http://www.rossconf.io",
-    "date": "September 26, 2015",
+    "startDate": "2015-09-26",
+    "endDate": "2015-09-26",
     "city": "Berlin",
     "country": "Germany",
     "twitter": "https://twitter.com/rossconf"
@@ -89,7 +100,8 @@
   {
     "name": "Rocky Mountain Ruby Conference",
     "url": "http://www.rockymtnruby.com",
-    "date": "September 23-25, 2015",
+    "startDate": "2015-09-23",
+    "endDate": "2015-09-25",
     "city": "Boulder",
     "country": "CO",
     "twitter": "https://twitter.com/rockymtnruby"
@@ -97,7 +109,8 @@
   {
     "name": "RubyConf Brazil",
     "url": "http://www.rubyconf.com.br",
-    "date": "September 18-19, 2015",
+    "startDate": "2015-09-18",
+    "endDate": "2015-09-19",
     "city": "São Paulo",
     "country": "Brazil",
     "twitter": "https://twitter.com/rubyconfbr"
@@ -105,7 +118,8 @@
   {
     "name": "WindyCityRails",
     "url": "http://www.windycityrails.org",
-    "date": "September 17-18, 2015",
+    "startDate": "2015-09-17",
+    "endDate": "2015-09-18",
     "city": "Chicago",
     "country": "IL",
     "twitter": "https://twitter.com/windycityrails"
@@ -113,7 +127,8 @@
   {
     "name": "RubyConf Portugal",
     "url": "http://rubyconf.pt",
-    "date": "September 14-15, 2015",
+    "startDate": "2015-09-14",
+    "endDate": "2015-09-15",
     "city": "Braga",
     "country": "Portugal",
     "twitter": "https://twitter.com/rubyconfpt"
@@ -121,7 +136,8 @@
   {
     "name": "RubyConf Taiwan",
     "url": "http://rubyconf.tw",
-    "date": "September 11-12, 2015",
+    "startDate": "2015-09-11",
+    "endDate": "2015-09-12",
     "city": "Taipei",
     "country": "Taiwan",
     "twitter": "https://twitter.com/rubytaiwan"
@@ -129,14 +145,16 @@
   {
     "name": "Barcelona Ruby Conf",
     "url": "http://www.baruco.org",
-    "date": "September 1-2, 2015",
+    "startDate": "2015-09-01",
+    "endDate": "2015-09-02",
     "city": "Barcelona",
     "country": "Spain",
     "twitter": "https://twitter.com/baruco"
   },
   {
     "name": "Ruby Midwest",
-    "date": "August 28-29, 2015",
+    "startDate": "2015-08-28",
+    "endDate": "2015-08-29",
     "city": "Kansas City",
     "country": "MO",
     "twitter": "https://twitter.com/rubymidwest"
@@ -144,7 +162,8 @@
   {
     "name": "Madison+ Ruby",
     "url": "http://madisonpl.us/ruby",
-    "date": "August 20-22, 2015",
+    "startDate": "2015-08-20",
+    "endDate": "2015-08-22",
     "city": "Madison",
     "country": "WI",
     "twitter": "https://twitter.com/madisonruby"
@@ -152,7 +171,8 @@
   {
     "name": "DeccanRubyConf",
     "url": "http://www.deccanrubyconf.org",
-    "date": "August 8, 2015",
+    "startDate": "2015-08-08",
+    "endDate": "2015-08-08",
     "city": "Pune",
     "country": "India",
     "twitter": "https://twitter.com/deccanrubyconf"
@@ -160,7 +180,8 @@
   {
     "name": "eurucamp",
     "url": "http://eurucamp.org",
-    "date": "July 31-August 2, 2015",
+    "startDate": "2015-07-31",
+    "endDate": "2015-08-02",
     "city": "Potsdam",
     "country": "Germany",
     "twitter": "https://twitter.com/eurucamp"
@@ -168,7 +189,8 @@
   {
     "name": "Burlington Ruby Conference",
     "url": "http://burlingtonruby.github.io/conference",
-    "date": "July 31-August 2, 2015",
+    "startDate": "2015-07-31",
+    "endDate": "2015-08-02",
     "city": "Burlington",
     "country": "VT",
     "twitter": "https://twitter.com/btvrubyconf"
@@ -176,7 +198,8 @@
   {
     "name": "JRubyConf EU",
     "url": "http://jrubyconf.eu",
-    "date": "July 31, 2015",
+    "startDate": "2015-07-31",
+    "endDate": "2015-07-31",
     "city": "Potsdam",
     "country": "Germany",
     "twitter": "https://twitter.com/jrubyconfeu"
@@ -184,7 +207,8 @@
   {
     "name": "Brighton Ruby",
     "url": "http://www.brightonruby.com",
-    "date": "July 20, 2015",
+    "startDate": "2015-07-20",
+    "endDate": "2015-07-20",
     "city": "Brighton",
     "country": "U.K.",
     "twitter": "https://twitter.com/brightonruby"
@@ -192,7 +216,8 @@
   {
     "name": "Gotham Ruby Conference",
     "url": "http://goruco.com",
-    "date": "June 20, 2015",
+    "startDate": "2015-06-20",
+    "endDate": "2015-06-20",
     "city": "New York",
     "country": "NY",
     "twitter": "https://twitter.com/goruco"
@@ -200,7 +225,8 @@
   {
     "name": "RubyNation",
     "url": "http://www.rubynation.org",
-    "date": "June 12-13, 2015",
+    "startDate": "2015-06-12",
+    "endDate": "2015-06-13",
     "city": "Washington",
     "country": "DC",
     "twitter": "https://twitter.com/rubynation"
@@ -208,21 +234,24 @@
   {
     "name": "RedDotRubyConf",
     "url": "http://www.reddotrubyconf.com",
-    "date": "June 4-5, 2015",
+    "startDate": "2015-06-04",
+    "endDate": "2015-06-05",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
   {
     "name": "Ruby Conference Kiev",
     "url": "http://rubyc.eu",
-    "date": "May 30-31, 2015",
+    "startDate": "2015-05-30",
+    "endDate": "2015-05-31",
     "city": "Kiev",
     "country": "Ukraine",
     "twitter": "https://twitter.com/rubyc_eu"
   },
   {
     "name": "RubyConf Kenya",
-    "date": "May 8-9, 2015",
+    "startDate": "2015-05-08",
+    "endDate": "2015-05-09",
     "city": "Nairobi",
     "country": "Kenya",
     "twitter": "https://twitter.com/nairubyke"
@@ -230,7 +259,8 @@
   {
     "name": "ROSSConf Vienna",
     "url": "http://www.rossconf.io",
-    "date": "April 25, 2015",
+    "startDate": "2015-04-25",
+    "endDate": "2015-04-25",
     "city": "Vienna",
     "country": "Austria",
     "twitter": "https://twitter.com/rossconf"
@@ -238,7 +268,8 @@
   {
     "name": "RailsConf",
     "url": "http://www.railsconf.com",
-    "date": "April 21-23, 2015",
+    "startDate": "2015-04-21",
+    "endDate": "2015-04-23",
     "city": "Atlanta",
     "country": "GA",
     "twitter": "https://twitter.com/railsconf"
@@ -246,7 +277,8 @@
   {
     "name": "Ruby Conf India",
     "url": "http://rubyconfindia.org",
-    "date": "April 3-5, 2015",
+    "startDate": "2015-04-03",
+    "endDate": "2015-04-05",
     "city": "Goa",
     "country": "India",
     "twitter": "https://twitter.com/rubyconfindia"
@@ -254,7 +286,8 @@
   {
     "name": "RubyConf Philippines",
     "url": "http://rubyconf.ph",
-    "date": "March 27-28, 2015",
+    "startDate": "2015-03-27",
+    "endDate": "2015-03-28",
     "city": "Boracay Island",
     "country": "Philippines",
     "twitter": "https://twitter.com/rubyconfph"
@@ -262,7 +295,8 @@
   {
     "name": "Ancient City Ruby",
     "url": "http://www.ancientcityruby.com",
-    "date": "March 26-27, 2015",
+    "startDate": "2015-03-26",
+    "endDate": "2015-03-27",
     "city": "St. Augustine",
     "country": "FL",
     "twitter": "https://twitter.com/ancientcityruby"
@@ -270,7 +304,8 @@
   {
     "name": "RubyConfLT",
     "url": "http://www.rubyconf.lt",
-    "date": "March 21, 2015",
+    "startDate": "2015-03-21",
+    "endDate": "2015-03-21",
     "city": "Vilnius",
     "country": "Lithuania",
     "twitter": "https://twitter.com/rubyconflt"
@@ -278,7 +313,8 @@
   {
     "name": "wroc_love.rb",
     "url": "http://wrocloverb.com",
-    "date": "March 13-15, 2015",
+    "startDate": "2015-03-13",
+    "endDate": "2015-03-15",
     "city": "Wrocław",
     "country": "Poland",
     "twitter": "https://twitter.com/wrocloverb"
@@ -286,7 +322,8 @@
   {
     "name": "Bath Ruby Conference",
     "url": "http://2015.bathruby.org",
-    "date": "March 13, 2015",
+    "startDate": "2015-03-13",
+    "endDate": "2015-03-13",
     "city": "Bath",
     "country": "U.K.",
     "twitter": "https://twitter.com/BathRuby"
@@ -294,7 +331,8 @@
   {
     "name": "MountainWest RubyConf",
     "url": "http://mtnwestrubyconf.org",
-    "date": "March 9-10, 2015",
+    "startDate": "2015-03-09",
+    "endDate": "2015-03-10",
     "city": "Salt Lake City",
     "country": "UT",
     "twitter": "https://twitter.com/mwrc"
@@ -302,14 +340,16 @@
   {
     "name": "Tropical Ruby",
     "url": "http://tropicalrb.com",
-    "date": "March 5-8, 2015",
+    "startDate": "2015-03-05",
+    "endDate": "2015-03-08",
     "city": "Porto de Galinhas",
     "country": "Brazil",
     "twitter": "https://twitter.com/tropicalrb"
   },
   {
     "name": "Ruby on Ales",
-    "date": "March 5-6, 2015",
+    "startDate": "2015-03-05",
+    "endDate": "2015-03-06",
     "city": "Bend",
     "country": "OR",
     "twitter": "https://twitter.com/rbonales"
@@ -317,7 +357,8 @@
   {
     "name": "Rubyfuza",
     "url": "http://rubyfuza.org",
-    "date": "February 5-6, 2015",
+    "startDate": "2015-02-05",
+    "endDate": "2015-02-06",
     "city": "Cape Town",
     "country": "South Africa",
     "twitter": "https://twitter.com/rubyfuza"
@@ -325,7 +366,8 @@
   {
     "name": "Ruby Conf Australia",
     "url": "http://www.rubyconf.org.au",
-    "date": "February 4-7, 2015",
+    "startDate": "2015-02-04",
+    "endDate": "2015-02-07",
     "city": "Melbourne",
     "country": "Australia",
     "twitter": "https://twitter.com/rubyconf_au"
@@ -333,7 +375,8 @@
   {
     "name": "Ruby devroom at FOSDEM",
     "url": "http://fosdem-ruby.github.io",
-    "date": "January 31 & February 1, 2015",
+    "startDate": "2015-01-31",
+    "endDate": "2015-02-01",
     "city": "Brussels",
     "country": "Belgium",
     "twitter": "https://twitter.com/ruby_fosdem"
@@ -341,7 +384,8 @@
   {
     "name": "Garden City RubyConf",
     "url": "http://www.gardencityruby.org",
-    "date": "January 10, 2015",
+    "startDate": "2015-01-10",
+    "endDate": "2015-01-10",
     "city": "Bangalore",
     "country": "India",
     "twitter": "https://twitter.com/gardencityrb"

--- a/conferences/2016/ruby.json
+++ b/conferences/2016/ruby.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "RubyConf Taiwan",
-    "date": "December 2-3, 2016",
+    "startDate": "2016-12-02",
+    "endDate": "2016-12-03",
     "city": "Taipei",
     "country": "Taiwan",
     "twitter": "https://twitter.com/rubyconftw"
@@ -9,14 +10,16 @@
   {
     "name": "RubyDay",
     "url": "http://www.rubyday.it",
-    "date": "November 25-26, 2016",
+    "startDate": "2016-11-25",
+    "endDate": "2016-11-26",
     "city": "Florence",
     "country": "Italy",
     "twitter": "https://twitter.com/rubydayit"
   },
   {
     "name": "Rail Israel",
-    "date": "November 14-15, 2016",
+    "startDate": "2016-11-14",
+    "endDate": "2016-11-15",
     "city": "Tel Aviv",
     "country": "Israel",
     "twitter": "https://twitter.com/railsisrael"
@@ -24,7 +27,8 @@
   {
     "name": "RubyConf",
     "url": "http://rubyconf.org",
-    "date": "November 10-12, 2016",
+    "startDate": "2016-11-10",
+    "endDate": "2016-11-12",
     "city": "Cincinnati",
     "country": "OH",
     "twitter": "https://twitter.com/rubyconf"
@@ -32,7 +36,8 @@
   {
     "name": "Keep Ruby Weird",
     "url": "http://keeprubyweird.com",
-    "date": "October 28, 2016",
+    "startDate": "2016-10-28",
+    "endDate": "2016-10-28",
     "city": "Austin",
     "country": "TX",
     "twitter": "https://twitter.com/keeprubyweird"
@@ -40,7 +45,8 @@
   {
     "name": "RubyConf Portugal",
     "url": "http://rubyconf.pt",
-    "date": "October 27-28, 2016",
+    "startDate": "2016-10-27",
+    "endDate": "2016-10-28",
     "city": "Braga",
     "country": "Portugal",
     "twitter": "https://twitter.com/rubyconfpt"
@@ -48,7 +54,8 @@
   {
     "name": "London Ruby Unconference",
     "url": "http://www.eventbrite.com/e/london-ruby-unconference-tickets-27663867372?aff=github",
-    "date": "October 22, 2016",
+    "startDate": "2016-10-22",
+    "endDate": "2016-10-22",
     "city": "London",
     "country": "U.K.",
     "twitter": "https://twitter.com/rubyunconf"
@@ -56,14 +63,16 @@
   {
     "name": "RailsClub",
     "url": "http://railsclub.ru/en/main.html",
-    "date": "October 22, 2016",
+    "startDate": "2016-10-22",
+    "endDate": "2016-10-22",
     "city": "Moscow",
     "country": "Russia",
     "twitter": "https://twitter.com/railsclub_ru"
   },
   {
     "name": "Conferencia Rails",
-    "date": "October 14-15, 2016",
+    "startDate": "2016-10-14",
+    "endDate": "2016-10-15",
     "city": "Madrid",
     "country": "Spain",
     "twitter": "https://twitter.com/conferenciaror"
@@ -71,7 +80,8 @@
   {
     "name": "RubyConf Brazil",
     "url": "http://www.rubyconf.com.br",
-    "date": "September 23-24, 2016",
+    "startDate": "2016-09-23",
+    "endDate": "2016-09-24",
     "city": "São Paulo",
     "country": "Brazil",
     "twitter": "https://twitter.com/rubyconfbr"
@@ -79,7 +89,8 @@
   {
     "name": "EuRuKo",
     "url": "http://euruko2016.org",
-    "date": "September 23-24, 2016",
+    "startDate": "2016-09-23",
+    "endDate": "2016-09-24",
     "city": "Sofia",
     "country": "Bulgaria",
     "twitter": "https://twitter.com/euruko"
@@ -87,7 +98,8 @@
   {
     "name": "Rocky Mountain Ruby",
     "url": "http://rockymtnruby.com",
-    "date": "September 21-23, 2016",
+    "startDate": "2016-09-21",
+    "endDate": "2016-09-23",
     "city": "Boulder",
     "country": "CO",
     "twitter": "https://twitter.com/rockymtnruby"
@@ -95,7 +107,8 @@
   {
     "name": "WindyCityRails",
     "url": "http://www.windycityrails.org",
-    "date": "September 15-16, 2016",
+    "startDate": "2016-09-15",
+    "endDate": "2016-09-16",
     "city": "Chicago",
     "country": "IL",
     "twitter": "https://twitter.com/windycityrails"
@@ -103,7 +116,8 @@
   {
     "name": "RubyKaigi",
     "url": "http://rubykaigi.org",
-    "date": "September 8-10, 2016",
+    "startDate": "2016-09-08",
+    "endDate": "2016-09-10",
     "city": "Kyoto",
     "country": "Japan",
     "twitter": "https://twitter.com/rubykaigi"
@@ -111,7 +125,8 @@
   {
     "name": "RubyConf Colombia",
     "url": "http://www.rubyconf.co",
-    "date": "September 2-3, 2016",
+    "startDate": "2016-09-02",
+    "endDate": "2016-09-03",
     "city": "Medellin",
     "country": "Colombia",
     "twitter": "https://twitter.com/rubyconfco"
@@ -119,7 +134,8 @@
   {
     "name": "Tech Day by GURU-PR",
     "url": "http://www.gurupr.org/eventos/2-tech-day-do-guru-pr",
-    "date": "August 20, 2016",
+    "startDate": "2016-08-20",
+    "endDate": "2016-08-20",
     "city": "Curitiba",
     "country": "Brazil",
     "twitter": "https://twitter.com/guru_pr"
@@ -127,7 +143,8 @@
   {
     "name": "RubyConf KL",
     "url": "http://www.rubyconf.my",
-    "date": "August 13, 2016",
+    "startDate": "2016-08-13",
+    "endDate": "2016-08-13",
     "city": "Kuala Lumpur",
     "country": "Malaysia",
     "twitter": "https://twitter.com/rubyconfmy"
@@ -135,7 +152,8 @@
   {
     "name": "Deccan Ruby Conference",
     "url": "http://www.deccanrubyconf.org",
-    "date": "August 6, 2016",
+    "startDate": "2016-08-06",
+    "endDate": "2016-08-06",
     "city": "Pune",
     "country": "India",
     "twitter": "https://twitter.com/deccanrubyconf"
@@ -143,7 +161,8 @@
   {
     "name": "Brighton Ruby Conference",
     "url": "http://brightonruby.com",
-    "date": "July 8, 2016",
+    "startDate": "2016-07-08",
+    "endDate": "2016-07-08",
     "city": "Brighton",
     "country": "U.K.",
     "twitter": "https://twitter.com/brightonruby"
@@ -151,7 +170,8 @@
   {
     "name": "OpenCommerce Conf",
     "url": "http://opencommerceconf.org",
-    "date": "June 28-29, 2016",
+    "startDate": "2016-06-28",
+    "endDate": "2016-06-29",
     "city": "Rise",
     "country": "New York City",
     "twitter": "https://twitter.com/opencommerce_"
@@ -159,14 +179,16 @@
   {
     "name": "GORUCO (Gotham Ruby Conference)",
     "url": "http://goruco.com",
-    "date": "June 25, 2016",
+    "startDate": "2016-06-25",
+    "endDate": "2016-06-25",
     "city": "New York",
     "country": "NY",
     "twitter": "https://twitter.com/goruco"
   },
   {
     "name": "GrillRB",
-    "date": "June 25-26, 2016",
+    "startDate": "2016-06-25",
+    "endDate": "2016-06-26",
     "city": "Wrocław",
     "country": "Poland",
     "twitter": "https://twitter.com/grill_rb"
@@ -174,21 +196,24 @@
   {
     "name": "RedDotRubyConf",
     "url": "http://www.reddotrubyconf.com",
-    "date": "June 23-24, 2016",
+    "startDate": "2016-06-23",
+    "endDate": "2016-06-24",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
   {
     "name": "NordicRuby",
     "url": "http://www.nordicruby.org",
-    "date": "June 17-19, 2016",
+    "startDate": "2016-06-17",
+    "endDate": "2016-06-19",
     "country": "Stockholm",
     "twitter": "https://twitter.com/nordicruby"
   },
   {
     "name": "Ruby for Good",
     "url": "http://www.rubyforgood.org",
-    "date": "June 16-19, 2016",
+    "startDate": "2016-06-16",
+    "endDate": "2016-06-19",
     "city": "Washington",
     "country": "DC",
     "twitter": "https://twitter.com/rubyforgood"
@@ -196,7 +221,8 @@
   {
     "name": "RubyC",
     "url": "http://rubyc.eu",
-    "date": "June 4-5, 2016",
+    "startDate": "2016-06-04",
+    "endDate": "2016-06-05",
     "city": "Kiev",
     "country": "Ukraine",
     "twitter": "https://twitter.com/rubyc_eu"
@@ -204,7 +230,8 @@
   {
     "name": "RubyNation",
     "url": "http://www.rubynation.org",
-    "date": "June 3-4, 2016",
+    "startDate": "2016-06-03",
+    "endDate": "2016-06-04",
     "city": "Washington",
     "country": "DC",
     "twitter": "https://twitter.com/rubynation"
@@ -212,7 +239,8 @@
   {
     "name": "Rails Pacific",
     "url": "http://www.railspacific.com",
-    "date": "May 20-21, 2016",
+    "startDate": "2016-05-20",
+    "endDate": "2016-05-21",
     "city": "Taipei",
     "country": "Taiwan",
     "twitter": "https://twitter.com/railspacific"
@@ -220,7 +248,8 @@
   {
     "name": "RailsConf",
     "url": "http://railsconf.com",
-    "date": "May 4-6, 2016",
+    "startDate": "2016-05-04",
+    "endDate": "2016-05-06",
     "city": "Kansas City",
     "country": "MO",
     "twitter": "https://twitter.com/railsconf"
@@ -228,7 +257,8 @@
   {
     "name": "RubyConfBY",
     "url": "http://rubyconference.by/en",
-    "date": "April 24, 2016",
+    "startDate": "2016-04-24",
+    "endDate": "2016-04-24",
     "city": "Minsk",
     "country": "Belarus",
     "twitter": "https://twitter.com/rubyconfby"
@@ -236,7 +266,8 @@
   {
     "name": "RubyConfLT",
     "url": "http://rubyconf.lt",
-    "date": "April 23, 2016",
+    "startDate": "2016-04-23",
+    "endDate": "2016-04-23",
     "city": "Vilnius",
     "country": "Lithuania",
     "twitter": "https://twitter.com/rubyconflt"
@@ -244,7 +275,8 @@
   {
     "name": "Rubyconf Philippines",
     "url": "http://rubyconf.ph",
-    "date": "April 7-9, 2016",
+    "startDate": "2016-04-07",
+    "endDate": "2016-04-09",
     "city": "Manila",
     "country": "Philippines",
     "twitter": "https://twitter.com/rubyconfph"
@@ -252,14 +284,16 @@
   {
     "name": "Ancient City Ruby",
     "url": "http://www.ancientcityruby.com",
-    "date": "April 6-8, 2016",
+    "startDate": "2016-04-06",
+    "endDate": "2016-04-08",
     "city": "St. Augustine",
     "country": "FL",
     "twitter": "https://twitter.com/ancientcityruby"
   },
   {
     "name": "Ruby on Ales",
-    "date": "March 31 & April 1, 2016",
+    "startDate": "2016-03-31",
+    "endDate": "2016-04-01",
     "city": "Bend",
     "country": "Oregon",
     "twitter": "https://twitter.com/rbonales"
@@ -267,7 +301,8 @@
   {
     "name": "MountainWest RubyConf",
     "url": "http://mtnwestrubyconf.org/2016",
-    "date": "March 21-22, 2016",
+    "startDate": "2016-03-21",
+    "endDate": "2016-03-22",
     "city": "Salt Lake City",
     "country": "UT",
     "twitter": "https://twitter.com/mwrc"
@@ -275,7 +310,8 @@
   {
     "name": "RubyConfIndia",
     "url": "http://rubyconfindia.org",
-    "date": "March 19-20, 2016",
+    "startDate": "2016-03-19",
+    "endDate": "2016-03-20",
     "city": "Kochi",
     "country": "India",
     "twitter": "https://twitter.com/rubyconfindia"
@@ -283,7 +319,8 @@
   {
     "name": "wroc_love.rb",
     "url": "http://wrocloverb.com",
-    "date": "March 11-13, 2016",
+    "startDate": "2016-03-11",
+    "endDate": "2016-03-13",
     "city": "Wrocław",
     "country": "Poland",
     "twitter": "https://twitter.com/wrocloverb"
@@ -291,7 +328,8 @@
   {
     "name": "Bath Ruby Conference",
     "url": "http://2016.bathruby.org",
-    "date": "March 11, 2016",
+    "startDate": "2016-03-11",
+    "endDate": "2016-03-11",
     "city": "Bath",
     "country": "U.K.",
     "twitter": "https://twitter.com/bathruby"
@@ -299,7 +337,8 @@
   {
     "name": "RubyConf Australia",
     "url": "http://www.rubyconf.org.au/2016",
-    "date": "February 10-13, 2016",
+    "startDate": "2016-02-10",
+    "endDate": "2016-02-13",
     "city": "Gold Coast",
     "country": "Australia",
     "twitter": "https://twitter.com/rubyconf_au"
@@ -307,7 +346,8 @@
   {
     "name": "Rubyfuza",
     "url": "http://www.rubyfuza.org",
-    "date": "February 4-5, 2016",
+    "startDate": "2016-02-04",
+    "endDate": "2016-02-05",
     "city": "Cape Town",
     "country": "South Africa",
     "twitter": "https://twitter.com/rubyfuza"
@@ -315,7 +355,8 @@
   {
     "name": "Ruby devroom at FOSDEM",
     "url": "http://fosdem.rubybelgium.be",
-    "date": "January 31, 2016",
+    "startDate": "2016-01-31",
+    "endDate": "2016-01-31",
     "city": "Brussels",
     "country": "Belgium",
     "twitter": "https://twitter.com/ruby_fosdem"

--- a/conferences/2016/ux.json
+++ b/conferences/2016/ux.json
@@ -2,324 +2,382 @@
   {
     "name": "Design Indaba",
     "url": "http://www.designindaba.com/tags/design-indaba-conference-2016",
-    "date": "Feb 17–19"
+    "startDate": "2016-02-17",
+    "endDate": "2016-02-19"
   },
   {
     "name": "Interaction 17",
     "url": "http://interaction17.ixda.org",
-    "date": "Feb 4-8",
+    "startDate": "2016-02-04",
+    "endDate": "2016-02-08",
     "city": "NYC"
   },
   {
     "name": "ConveyUX",
     "url": "http://conveyux.com",
-    "date": "Feb28-March2",
+    "startDate": "2016-02-28",
+    "endDate": "2016-03-02",
     "city": "Seattle"
   },
   {
     "name": "Intelligent Content",
     "url": "http://www.intelligentcontentconference.com",
-    "date": "Mar 28-30",
+    "startDate": "2016-03-28",
+    "endDate": "2016-03-30",
     "city": "Vegas, baby"
   },
   {
     "name": "Cambridge Workshop on Universal Access and Assistive Tech",
     "url": "http://www-edc.eng.cam.ac.uk/cwuaat",
-    "date": "March 21–23"
+    "startDate": "2016-03-21",
+    "endDate": "2016-03-23"
   },
   {
     "name": "Customer Experience Conf",
     "url": "https://www.conference-board.org/conferences/conferencedetail.cfm?conferenceid=2774",
-    "date": "March 23–24"
+    "startDate": "2016-03-23",
+    "endDate": "2016-03-24"
   },
   {
     "name": "UX Burlington",
     "url": "http://uxburlington.com",
-    "date": "4/29/2016"
+    "startDate": "2016-04-29",
+    "endDate": "2016-04-29"
   },
   {
     "name": "IA Summit ",
     "url": "http://www.iasummit.org",
-    "date": "March 22-26",
+    "startDate": "2016-03-22",
+    "endDate": "2016-03-26",
     "city": "Vancouver!"
   },
   {
     "name": "DIBIConference",
     "url": "http://www.dibiconference.com",
-    "date": "March 30-31"
+    "startDate": "2016-03-30",
+    "endDate": "2016-03-31"
   },
   {
     "name": "Clarity - design systems conf",
-    "url": "http://clarityconf.com"
+    "url": "http://clarityconf.com",
+    "startDate": "2016-03-31",
+    "endDate": "2016-04-01"
   },
   {
     "name": "WAQ",
     "url": "https://webaquebec.org",
-    "date": "April 4-6"
+    "startDate": "2016-04-04",
+    "endDate": "2016-04-06"
   },
   {
     "name": "How To Create Products Customers Love",
     "url": "http://svpg.com/how-to-create-products-customers-love-2",
-    "date": "April 11–12",
+    "startDate": "2016-04-11",
+    "endDate": "2016-04-12",
     "city": "Quebec City"
   },
   {
     "name": "Unite",
     "url": "https://unite.shopify.com",
-    "date": "April 20–21",
+    "startDate": "2016-04-20",
+    "endDate": "2016-04-21",
     "city": "San Fran"
   },
   {
     "name": "Write the Docs",
     "url": "http://www.writethedocs.org",
-    "date": "May 14-16",
+    "startDate": "2016-05-14",
+    "endDate": "2016-05-16",
     "city": "San Fran"
   },
   {
     "name": "Design Management Conference Europe",
     "url": "http://www.dmi.org/?Adam2016Overview",
-    "date": "May 23–25",
+    "startDate": "2016-05-23",
+    "endDate": "2016-05-25",
     "city": "Portland, OR"
   },
   {
     "name": "Design Science Research in Information Systems and Technologies (DESRIST) 2016 Conference",
     "url": "https://desrist2016.wordpress.com",
-    "date": "May 24–25"
+    "startDate": "2016-05-24",
+    "endDate": "2016-05-25"
   },
   {
     "name": "UXPA",
     "url": "http://uxpa.github.io",
-    "date": "June 5 - 8",
+    "startDate": "2016-06-05",
+    "endDate": "2016-06-08",
     "city": "Toronto",
     "country": "Canada"
   },
   {
     "name": "Enterprise UX",
     "url": "http://promo.rosenfeldmedia.com/euxsignup2017",
-    "date": "June 7-9 ",
+    "startDate": "2016-06-07",
+    "endDate": "2016-06-09",
     "city": "San Fran"
   },
   {
     "name": "Confab Central",
     "url": "http://confabevents.com",
-    "date": "June 7-9 ",
+    "startDate": "2016-06-07",
+    "endDate": "2016-06-09",
     "city": "Minneapolis"
   },
   {
     "name": "UX Scotland",
     "url": "http://uxscotland.net/2017",
-    "date": "June 7-9 "
+    "startDate": "2016-06-07",
+    "endDate": "2016-06-09"
   },
   {
     "name": "Collective",
     "url": "http://collectiveconf.com",
-    "date": "June 8–10"
+    "startDate": "2016-06-08",
+    "endDate": "2016-06-10"
   },
   {
     "name": "UX Strat 2017",
     "url": "http://www.uxstrat.com/europe",
-    "date": "June 15-18",
+    "startDate": "2016-06-15",
+    "endDate": "2016-06-18",
     "city": "Amsterdam"
   },
   {
     "name": "UXcamp Europe",
     "url": "http://www.uxcampeurope.org",
-    "date": "June 25-26"
+    "startDate": "2016-06-25",
+    "endDate": "2016-06-26"
   },
   {
     "name": "Eyeo 2017",
     "url": "http://eyeofestival.com",
-    "date": "June 26-29",
+    "startDate": "2016-06-26",
+    "endDate": "2016-06-29",
     "city": "MINNEAPOLIS"
   },
   {
     "name": "Design Research Society Conf",
     "url": "http://www.drs2016.org",
-    "date": "June 27–30 ",
+    "startDate": "2016-06-27",
+    "endDate": "2016-06-30",
     "city": "[not until 2018]"
   },
   {
     "name": "LavaCon Dublin",
     "url": "http://lavacon.org/2016/dublin",
-    "date": "June 5-7"
+    "startDate": "2016-06-05",
+    "endDate": "2016-06-07"
   },
   {
     "name": "Internation Conference of Experience Design",
     "url": "http://ixdc.org/2016/en/index.php",
-    "date": "June 29–July 3"
+    "startDate": "2016-06-29",
+    "endDate": "2016-07-03"
   },
   {
     "name": "What Design Can Do",
     "url": "http://www.whatdesigncando.com/amsterdam-2016",
-    "date": "June 30–July 1",
+    "startDate": "2016-06-30",
+    "endDate": "2016-07-01",
     "city": "Amsterdam"
   },
   {
     "name": "Design and Content Conf",
     "url": "https://designcontentconf.com",
-    "date": "July 17-19",
+    "startDate": "2016-07-17",
+    "endDate": "2016-07-19",
     "city": "Vancouver"
   },
   {
     "name": "AHFE 2016 ",
     "url": "http://www.ahfe2016.org",
-    "date": "July 27–31 "
+    "startDate": "2016-07-27",
+    "endDate": "2016-07-31"
   },
   {
     "name": "UX Week",
     "url": "http://uxweek.com",
-    "date": "Aug29-Sept1",
+    "startDate": "2016-08-29",
+    "endDate": "2016-09-01",
     "city": "San Fran"
   },
   {
     "name": "The Conference",
     "url": "http://2017.theconference.se",
-    "date": "Sept 4-5",
+    "startDate": "2016-09-04",
+    "endDate": "2016-09-05",
     "city": "Malmo, Sweden"
   },
   {
     "name": "MobileHCI",
     "url": "http://mobilehci.acm.org/2017",
-    "date": "Sept 4-7",
+    "startDate": "2016-09-04",
+    "endDate": "2016-09-07",
     "city": "Vienna, Austria"
   },
   {
     "name": "MOBX (Mobile UX)",
     "url": "https://2017.mobxcon.com",
-    "date": "Sept 7-8",
+    "startDate": "2016-09-07",
+    "endDate": "2016-09-08",
     "city": "Berlin, Germany"
   },
   {
     "name": "Brand New Conference",
     "url": "http://www.underconsideration.com/brandnewconference",
-    "date": "Sept 14-15",
+    "startDate": "2016-09-14",
+    "endDate": "2016-09-15",
     "city": "Chicago"
   },
   {
     "name": "UX Strat USA",
     "url": "http://www.uxstrat.com/usa",
-    "date": "Sept 18-20",
+    "startDate": "2016-09-18",
+    "endDate": "2016-09-20",
     "city": "Boulder, CO"
   },
   {
     "name": "Confab Intensive",
     "url": "http://confabevents.com/events/intensive/2016",
-    "date": "Sept 11-13",
+    "startDate": "2016-09-11",
+    "endDate": "2016-09-13",
     "city": "Denver, CO"
   },
   {
     "name": "EuroIA",
     "url": "http://www.euroia.org",
-    "date": "Sept 28-30",
+    "startDate": "2016-09-28",
+    "endDate": "2016-09-30",
     "city": "Stockholm"
   },
   {
     "name": "Write the Docs Europe",
-    "url": "---",
-    "date": "FALL 2017"
+    "url": "http://www.writethedocs.org/conf/eu/2016/",
+    "startDate": "2016-09-18",
+    "endDate": "2016-09-20",
+    "city": "Prague"
   },
   {
     "name": "Design Leadership Conference",
     "url": "http://www.dmi.org/?page=Conferences",
-    "date": "Sept 24-26",
+    "startDate": "2016-09-24",
+    "endDate": "2016-09-26",
     "city": "Minneapolis"
   },
   {
     "name": "Fluxible ",
     "url": "http://www.fluxible.ca",
-    "date": "Sept 18-24",
+    "startDate": "2016-09-18",
+    "endDate": "2016-09-24",
     "city": "Waterloo, ON"
   },
   {
     "name": "Design Matters '17",
     "url": "https://designmatters.io",
-    "date": "Sept 27-28",
+    "startDate": "2016-09-27",
+    "endDate": "2016-09-28",
     "city": "Copenhagen, Denmark"
   },
   {
     "name": "Interact",
     "url": "https://www.interact2017.org",
-    "date": "Sept 25-29",
+    "startDate": "2016-09-25",
+    "endDate": "2016-09-29",
     "city": "Mumbai, India"
   },
   {
     "name": "Content Strategy Forum",
     "url": "http://contentark.com.au/content-strategy-forum-2016",
-    "date": "Unknown"
+    "startDate": "2016-10-05",
+    "endDate": "2016-10-07"
   },
   {
     "name": "GIANT Conference",
     "url": "http://www.giantconf.com/details",
-    "date": "Oct 17–19"
+    "startDate": "2016-10-17",
+    "endDate": "2016-10-19"
   },
   {
     "name": "SmashingConf",
     "url": "https://smashingconf.com/barcelona-2017",
-    "date": "Oct 17-18",
+    "startDate": "2016-10-17",
+    "endDate": "2016-10-18",
     "city": "Barcelona, Spain"
   },
   {
     "name": "EPIC Conf",
     "url": "https://www.epicpeople.org",
-    "date": "Oct 22-25",
+    "startDate": "2016-10-22",
+    "endDate": "2016-10-25",
     "city": "Montreal!"
   },
   {
     "name": "Design Thinkers",
     "url": "https://www.designthinkers.com/News/2017/DesignThinkers-Montreal-2017.aspx",
-    "date": "Oct 19-20",
+    "startDate": "2016-10-19",
+    "endDate": "2016-10-20",
     "city": "Montreal"
   },
   {
     "name": "LavaCon",
     "url": "https://lavacon.org/2017/portland",
-    "date": "Nov 5-8",
+    "startDate": "2016-11-05",
+    "endDate": "2016-11-08",
     "city": "Portland, Oregon"
   },
   {
     "name": "Productized",
     "url": "http://www.productized.co",
-    "date": "October?",
+    "startDate": "2016-10-19",
+    "endDate": "2016-10-21",
     "city": "Lisbon, Portugal"
   },
   {
     "name": "Pop Tech",
     "url": "http://poptech.org/conferences",
-    "date": "October 19-21",
+    "startDate": "2016-10-19",
+    "endDate": "2016-10-21",
     "city": "Camden, Maine"
   },
   {
     "name": "Service Design Network Conf",
     "url": "http://www.service-design-network.org/conferences",
-    "date": "Oct / Nov?"
+    "startDate": "2016-10-27",
+    "endDate": "2016-10-28"
   },
   {
     "name": "Beyond Tellerrand",
     "url": "https://beyondtellerrand.com",
-    "date": "Nov 6-8",
+    "startDate": "2016-11-06",
+    "endDate": "2016-11-08",
     "city": "Berlin, Germany"
   },
   {
     "name": "CanUX",
     "url": "http://canux.io",
-    "date": "Nov 3-5",
+    "startDate": "2016-11-03",
+    "endDate": "2016-11-05",
     "city": "Ottawa"
   },
   {
     "name": "Gather North",
     "url": "https://gathernorth.com",
-    "date": "Nov 17-19",
+    "startDate": "2016-11-17",
+    "endDate": "2016-11-19",
     "city": "Montebello, Quebec"
   },
   {
     "name": "Taxonomy boot camp",
     "url": "http://www.taxonomybootcamp.com/2017/default.aspx",
-    "date": "Nov 6-7",
+    "startDate": "2016-11-06",
+    "endDate": "2016-11-07",
     "city": "Washington, DC"
   },
   {
     "name": "Delight",
     "url": "http://delight.us/conference",
-    "date": "May 2018"
+    "startDate": "2016-12-08"
   }
 ]

--- a/conferences/2017/css.json
+++ b/conferences/2017/css.json
@@ -23,8 +23,8 @@
   {
     "name": "CSS Day",
     "url": "https://cssday.nl/2017",
-    "date": "July 15-16",
-    "startDate": "2017-07-15",
+    "startDate": "2017-06-15",
+    "endDate": "2017-06-16",
     "city": "Amsterdam",
     "country": "Netherlands"
   },

--- a/conferences/2017/ux.json
+++ b/conferences/2017/ux.json
@@ -9,8 +9,8 @@
   {
     "name": "Interaction 17",
     "url": "http://interaction17.ixda.org",
-    "date": "Feb 4-8",
     "startDate": "2017-02-04",
+    "endDate": "2017-02-08",
     "city": "New York City",
     "country": "U.S.A."
   },
@@ -38,32 +38,32 @@
   {
     "name": "IA Summit ",
     "url": "http://www.iasummit.org",
-    "date": "March 22-26",
     "startDate": "2017-03-22",
+    "endDate": "2017-03-26",
     "city": "Vancouver",
     "country": "Canada"
   },
   {
     "name": "Intelligent Content",
     "url": "http://www.intelligentcontentconference.com",
-    "date": "Mar 28-30",
-    "startDate": "2017-03-23",
+    "startDate": "2017-03-28",
+    "endDate": "2017-03-30",
     "city": "Las Vegas",
     "country": "U.S.A."
   },
   {
     "name": "ConveyUX",
     "url": "http://conveyux.com",
-    "date": "Feb28-March2",
-    "startDate": "2017-03-28",
+    "startDate": "2017-02-28",
+    "endDate": "2017-03-02",
     "city": "Seattle",
     "country": "U.S.A."
   },
   {
     "name": "Customer Experience Conf",
     "url": "https://www.conference-board.org/conferences/conferencedetail.cfm?conferenceid=2774",
-    "date": "March 23–24",
-    "startDate": "2017-03-28",
+    "startDate": "2017-03-23",
+    "endDate": "2017-03-24",
     "city": "New York City",
     "country": "U.S.A."
   },
@@ -77,24 +77,24 @@
   {
     "name": "WAQ",
     "url": "https://webaquebec.org",
-    "date": "April 4-6",
     "startDate": "2017-04-04",
+    "endDate": "2017-04-06",
     "city": "Quebec",
     "country": "Canada"
   },
   {
     "name": "How To Create Products Customers Love",
     "url": "http://svpg.com/how-to-create-products-customers-love-2",
-    "date": "April 11–12",
     "startDate": "2017-04-11",
+    "endDate": "2017-04-12",
     "city": "Quebec City",
     "country": "Canada"
   },
   {
     "name": "Unite",
     "url": "https://unite.shopify.com",
-    "date": "April 20–21",
     "startDate": "2017-04-20",
+    "endDate": "2017-04-21",
     "city": "San Fransisco",
     "country": "U.S.A."
   },
@@ -122,8 +122,8 @@
   {
     "name": "Write the Docs",
     "url": "http://www.writethedocs.org",
-    "date": "May 14-16",
     "startDate": "2017-05-14",
+    "endDate": "2017-05-16",
     "city": "San Fransisco",
     "country": "U.S.A."
   },
@@ -178,24 +178,24 @@
   {
     "name": "UXPA",
     "url": "http://uxpa.github.io",
-    "date": "June 5 - 8",
     "startDate": "2017-06-05",
+    "endDate": "2017-06-08",
     "city": "St John's, NL",
     "country": "Canada"
   },
   {
     "name": "Confab Central",
     "url": "http://confabevents.com",
-    "date": "June 7-9 ",
     "startDate": "2017-06-07",
+    "endDate": "2017-06-09",
     "city": "Minneapolis",
     "country": "Minneapolis"
   },
   {
     "name": "Enterprise UX",
     "url": "http://promo.rosenfeldmedia.com/euxsignup2017",
-    "date": "June 7-9 ",
     "startDate": "2017-06-07",
+    "endDate": "2017-06-09",
     "city": "San Fransisco",
     "country": "U.S.A."
   },
@@ -210,8 +210,8 @@
   {
     "name": "Collective",
     "url": "http://collectiveconf.com",
-    "date": "June 8–10",
     "startDate": "2017-06-08",
+    "endDate": "2017-06-10",
     "city": "Atlanta",
     "country": "U.S.A."
   },
@@ -225,24 +225,24 @@
   {
     "name": "UX Strat",
     "url": "http://www.uxstrat.com/europe",
-    "date": "June 15-18",
     "startDate": "2017-06-15",
+    "endDate": "2017-06-18",
     "city": "Amsterdam",
     "country": "Netherlands"
   },
   {
     "name": "UXcamp Europe",
     "url": "http://www.uxcampeurope.org",
-    "date": "June 25-26",
     "startDate": "2017-06-25",
+    "endDate": "2017-06-26",
     "city": "Berlin",
     "country": "Germany"
   },
   {
     "name": "Eyeo",
     "url": "http://eyeofestival.com",
-    "date": "June 26-29",
     "startDate": "2017-06-26",
+    "endDate": "2017-06-29",
     "city": "Minneapolis",
     "country": "U.S.A."
   },
@@ -256,8 +256,8 @@
   {
     "name": "Design and Content Conf",
     "url": "https://designcontentconf.com",
-    "date": "July 17-19",
     "startDate": "2017-07-17",
+    "endDate": "2017-07-19",
     "city": "Vancouver",
     "country": "Vancouver"
   },
@@ -273,8 +273,8 @@
   {
     "name": "MobileHCI",
     "url": "http://mobilehci.acm.org/2017",
-    "date": "Sept 4-7",
     "startDate": "2017-09-04",
+    "endDate": "2017-09-07",
     "city": "Vienna",
     "country": "Austria"
   },
@@ -298,8 +298,8 @@
   {
     "name": "MOBX (Mobile UX)",
     "url": "https://2017.mobxcon.com",
-    "date": "Sept 7-8",
     "startDate": "2017-09-07",
+    "endDate": "2017-09-08",
     "city": "Berlin",
     "country": "Germany"
   },
@@ -313,8 +313,8 @@
   {
     "name": "Brand New Conference",
     "url": "http://www.underconsideration.com/brandnewconference",
-    "date": "Sept 14-15",
     "startDate": "2017-09-14",
+    "endDate": "2017-09-15",
     "city": "Chicago",
     "country": "U.S.A."
   },
@@ -330,8 +330,8 @@
   {
     "name": "UX Strat USA",
     "url": "http://www.uxstrat.com/usa",
-    "date": "Sept 18-20",
     "startDate": "2017-09-18",
+    "endDate": "2017-09-20",
     "city": "Boulder, CO",
     "country": "U.S.A."
   },
@@ -363,8 +363,8 @@
   {
     "name": "Design Leadership Conference",
     "url": "http://www.dmi.org/?page=Conferences",
-    "date": "Sept 24-26",
     "startDate": "2017-09-24",
+    "endDate": "2017-09-26",
     "city": "Minneapolis",
     "country": "U.S.A."
   },
@@ -387,8 +387,8 @@
   {
     "name": "EuroIA",
     "url": "http://www.euroia.org",
-    "date": "Sept 28-30",
     "startDate": "2017-09-28",
+    "endDate": "2017-09-30",
     "city": "Stockholm",
     "country": "Sweden"
   },
@@ -404,15 +404,14 @@
   {
     "name": "UX Week",
     "url": "http://uxweek.com",
-    "date": "Aug29-Sept1",
-    "startDate": "2017-09-29",
+    "startDate": "2017-08-29",
+    "endDate": "2017-09-01",
     "city": "San Fransisco",
     "country": "U.S.A."
   },
   {
     "name": "Productized",
     "url": "http://www.productized.co",
-    "date": "October?",
     "startDate": "2017-10-01",
     "city": "Lisbon",
     "country": "Portugal"
@@ -454,7 +453,6 @@
   {
     "name": "Smashing Conference",
     "url": "https://smashingconf.com/barcelona-2017",
-    "date": "Oct 17-18",
     "startDate": "2017-10-17",
     "endDate": "2017-10-18",
     "city": "Barcelona",
@@ -472,24 +470,24 @@
   {
     "name": "Design Thinkers",
     "url": "https://www.designthinkers.com/News/2017/DesignThinkers-Montreal-2017.aspx",
-    "date": "Oct 19-20",
     "startDate": "2017-10-19",
+    "endDate": "2017-10-20",
     "city": "Montreal",
     "country": "Canada"
   },
   {
     "name": "Pop Tech",
     "url": "http://poptech.org/conferences",
-    "date": "October 19-21",
     "startDate": "2017-10-19",
+    "endDate": "2017-10-21",
     "city": "Camden, Maine",
     "country": "U.S.A."
   },
   {
     "name": "EPIC Conf",
     "url": "https://www.epicpeople.org",
-    "date": "Oct 22-25",
     "startDate": "2017-10-22",
+    "endDate": "2017-10-25",
     "city": "Montreal",
     "country": "Canada"
   },
@@ -539,32 +537,32 @@
   {
     "name": "CanUX",
     "url": "http://canux.io",
-    "date": "Nov 3-5",
     "startDate": "2017-11-03",
+    "endDate": "2017-11-05",
     "city": "Ottawa",
     "country": "Canada"
   },
   {
     "name": "LavaCon",
     "url": "https://lavacon.org/2017/portland",
-    "date": "Nov 5-8",
     "startDate": "2017-11-05",
+    "endDate": "2017-11-08",
     "city": "Portland, Oregon",
     "country": "U.S.A."
   },
   {
     "name": "Beyond Tellerrand",
     "url": "https://beyondtellerrand.com",
-    "date": "Nov 6-8",
     "startDate": "2017-11-06",
+    "endDate": "2017-11-08",
     "city": "Berlin",
     "country": "Germany"
   },
   {
     "name": "Taxonomy boot camp",
     "url": "http://www.taxonomybootcamp.com/2017/default.aspx",
-    "date": "Nov 6-7",
     "startDate": "2017-11-06",
+    "endDate": "2017-11-07",
     "city": "Washington, DC",
     "country": "U.S.A."
   },
@@ -589,7 +587,6 @@
   {
     "name": "DIBIConference",
     "url": "http://www.dibiconference.com",
-    "date": "November 10",
     "startDate": "2017-11-10",
     "city": "Newcastle",
     "country": "U.K."
@@ -597,8 +594,8 @@
   {
     "name": "Gather North",
     "url": "https://gathernorth.com",
-    "date": "Nov 17-19",
     "startDate": "2017-11-17",
+    "endDate": "2017-11-19",
     "city": "Montebello, Quebec",
     "country": "Canada"
   },
@@ -612,8 +609,8 @@
   {
     "name": "Clarity - design systems conf",
     "url": "http://clarityconf.com",
-    "date": "November 28, 30",
     "startDate": "2017-11-28",
+    "endDate": "2017-11-30",
     "city": "San Francisco",
     "country": "U.S.A."
   },

--- a/conferences/2018/ios.json
+++ b/conferences/2018/ios.json
@@ -12,8 +12,8 @@
   {
     "name": "Forward Swift",
     "url": "https://forwardswift.com",
-    "startDate": "2018-02",
-    "endDate": "2018-02",
+    "startDate": "2018-02-11",
+    "endDate": "2018-02-15",
     "city": "San Francisco",
     "country": "U.S.A."
   },


### PR DESCRIPTION
Hi all,

I am using this data for a project of mine and noticed the dates in some of the older conferences are not in standard format.

So I took the time to fix the dates (mainly 2017 and before).

All conferences should now have at least a `startDate` property in "YYYY-MM-DD"-Format. `date` property has been removed from all confs.



