### PR TITLE
Fix location properties

### DIFF
--- a/conferences/2014/ruby.json
+++ b/conferences/2014/ruby.json
@@ -4,8 +4,8 @@
     "url": "http://rubyconf.org",
     "startDate": "2014-11-17",
     "endDate": "2014-11-19",
-    "city": "San Diego",
-    "country": "CA",
+    "city": "San Diego, CA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubyconf"
   },
   {
@@ -40,8 +40,8 @@
     "url": "http://keeprubyweird.com",
     "startDate": "2014-10-24",
     "endDate": "2014-10-24",
-    "city": "Austin",
-    "country": "TX",
+    "city": "Austin, TX",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/keeprubyweird"
   },
   {
@@ -58,8 +58,8 @@
     "url": "http://rubydcamp.org",
     "startDate": "2014-10-10",
     "endDate": "2014-10-12",
-    "city": "Prince William Forest Park",
-    "country": "VA",
+    "city": "Prince William Forest Park, VA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/ruby_dcamp"
   },
   {
@@ -67,8 +67,8 @@
     "url": "http://nickelcityruby.com",
     "startDate": "2014-10-03",
     "endDate": "2014-10-04",
-    "city": "Buffalo",
-    "country": "NY",
+    "city": "Buffalo, NY",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/nickelcityruby"
   },
   {
@@ -103,16 +103,17 @@
     "url": "http://rockymtnruby.com",
     "startDate": "2014-09-25",
     "endDate": "2014-09-26",
-    "city": "Boulder",
-    "country": "CO",
+    "city": "Boulder, CO",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rockymtnruby"
   },
   {
     "name": "Golden Gate Ruby Conference",
+    "url": "http://gogaruco.com/",
     "startDate": "2014-09-19",
     "endDate": "2014-09-20",
-    "city": "San Francisco",
-    "country": "CA",
+    "city": "San Francisco, CA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/gogaruco"
   },
   {
@@ -147,8 +148,8 @@
     "url": "http://www.windycityrails.org",
     "startDate": "2014-09-04",
     "endDate": "2014-09-05",
-    "city": "Chicago",
-    "country": "IL",
+    "city": "Chicago, IL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/windycityrails"
   },
   {
@@ -174,8 +175,8 @@
     "url": "http://madisonpl.us/ruby",
     "startDate": "2014-08-22",
     "endDate": "2014-08-23",
-    "city": "Madison",
-    "country": "WI",
+    "city": "Madison, WI",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/madisonruby"
   },
   {
@@ -183,8 +184,8 @@
     "url": "http://cascadiaruby.com",
     "startDate": "2014-08-11",
     "endDate": "2014-08-12",
-    "city": "Portland",
-    "country": "OR",
+    "city": "Portland, OR",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/cascadiaruby"
   },
   {
@@ -210,8 +211,8 @@
     "url": "http://burlingtonruby.github.io/conference",
     "startDate": "2014-08-01",
     "endDate": "2014-08-03",
-    "city": "Burlington",
-    "country": "VT",
+    "city": "Burlington, VT",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/btvrubyconf"
   },
   {
@@ -237,6 +238,7 @@
     "url": "http://reddotrubyconf.com",
     "startDate": "2014-06-26",
     "endDate": "2014-06-27",
+    "city": "Singapore",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
@@ -245,8 +247,8 @@
     "url": "http://goruco.com",
     "startDate": "2014-06-21",
     "endDate": "2014-06-21",
-    "city": "New York",
-    "country": "NY",
+    "city": "New York, NY",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/goruco"
   },
   {
@@ -263,8 +265,8 @@
     "url": "http://www.rubynation.org",
     "startDate": "2014-06-06",
     "endDate": "2014-06-07",
-    "city": "Washington",
-    "country": "DC",
+    "city": "Washington, DC",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubynation"
   },
   {
@@ -281,12 +283,13 @@
     "url": "http://www.rubymotion.com/conference/2014",
     "startDate": "2014-05-28",
     "endDate": "2014-05-29",
-    "city": "San Francisco",
-    "country": "CA",
+    "city": "San Francisco, CA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubymotion"
   },
   {
     "name": "RubyConf Uruguay",
+    "url": "http://www.rubyconfuruguay.org/",
     "startDate": "2014-05-23",
     "endDate": "2014-05-24",
     "city": "Montevideo",
@@ -325,8 +328,8 @@
     "url": "http://www.railsconf.com",
     "startDate": "2014-04-22",
     "endDate": "2014-04-25",
-    "city": "Chicago",
-    "country": "IL",
+    "city": "Chicago, IL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/railsconf"
   },
   {
@@ -334,8 +337,8 @@
     "url": "http://www.ancientcityruby.com",
     "startDate": "2014-04-03",
     "endDate": "2014-04-04",
-    "city": "St. Augustine",
-    "country": "FL",
+    "city": "St. Augustine, FL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/ancientcityruby"
   },
   {
@@ -361,8 +364,8 @@
     "url": "http://mtnwestrubyconf.org",
     "startDate": "2014-03-20",
     "endDate": "2014-03-21",
-    "city": "Salt Lake City",
-    "country": "UT",
+    "city": "Salt Lake City, UT",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/mwrc"
   },
   {
@@ -376,14 +379,16 @@
   },
   {
     "name": "Ruby on Ales",
+    "url": "https://ruby.onales.com/",
     "startDate": "2014-03-06",
     "endDate": "2014-03-07",
-    "city": "Bend",
-    "country": "OR",
+    "city": "Bend, OR",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rbonales"
   },
   {
     "name": "RubySauna",
+    "url": "http://www.rubysauna.org/",
     "startDate": "2014-02-27",
     "endDate": "2014-02-27",
     "city": "Oulu",
@@ -392,10 +397,11 @@
   },
   {
     "name": "Big Ruby",
+    "url": "http://bigrubyconf.com/",
     "startDate": "2014-02-20",
     "endDate": "2014-02-21",
-    "city": "Dallas",
-    "country": "TX",
+    "city": "Dallas, TX",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/bigrubyconf"
   },
   {
@@ -409,10 +415,11 @@
   },
   {
     "name": "Los Angeles Ruby Conference",
+    "url": "https://www.larubyconf.com/past?year=2014",
     "startDate": "2014-02-08",
     "endDate": "2014-02-08",
-    "city": "Los Angeles",
-    "country": "CA",
+    "city": "Los Angeles, CA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/larubyconf"
   },
   {

--- a/conferences/2015/ruby.json
+++ b/conferences/2015/ruby.json
@@ -22,8 +22,8 @@
     "url": "http://rubyconf.org",
     "startDate": "2015-11-15",
     "endDate": "2015-11-17",
-    "city": "San Antonio",
-    "country": "TX",
+    "city": "San Antonio, TX",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubyconf"
   },
   {
@@ -73,10 +73,11 @@
   },
   {
     "name": "Los Angeles Ruby Conference",
+    "url": "https://www.larubyconf.com/",
     "startDate": "2015-10-10",
     "endDate": "2015-10-10",
-    "city": "Los Angeles",
-    "country": "CA",
+    "city": "Los Angeles, CA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/larubyconf"
   },
   {
@@ -102,8 +103,8 @@
     "url": "http://www.rockymtnruby.com",
     "startDate": "2015-09-23",
     "endDate": "2015-09-25",
-    "city": "Boulder",
-    "country": "CO",
+    "city": "Boulder, CO",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rockymtnruby"
   },
   {
@@ -120,8 +121,8 @@
     "url": "http://www.windycityrails.org",
     "startDate": "2015-09-17",
     "endDate": "2015-09-18",
-    "city": "Chicago",
-    "country": "IL",
+    "city": "Chicago, IL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/windycityrails"
   },
   {
@@ -153,10 +154,11 @@
   },
   {
     "name": "Ruby Midwest",
+    "url": "http://www.rubymidwest.com/",
     "startDate": "2015-08-28",
     "endDate": "2015-08-29",
-    "city": "Kansas City",
-    "country": "MO",
+    "city": "Kansas City, MO",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubymidwest"
   },
   {
@@ -164,8 +166,8 @@
     "url": "http://madisonpl.us/ruby",
     "startDate": "2015-08-20",
     "endDate": "2015-08-22",
-    "city": "Madison",
-    "country": "WI",
+    "city": "Madison, WI",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/madisonruby"
   },
   {
@@ -191,8 +193,8 @@
     "url": "http://burlingtonruby.github.io/conference",
     "startDate": "2015-07-31",
     "endDate": "2015-08-02",
-    "city": "Burlington",
-    "country": "VT",
+    "city": "Burlington, VT",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/btvrubyconf"
   },
   {
@@ -218,8 +220,8 @@
     "url": "http://goruco.com",
     "startDate": "2015-06-20",
     "endDate": "2015-06-20",
-    "city": "New York",
-    "country": "NY",
+    "city": "New York, NY",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/goruco"
   },
   {
@@ -227,8 +229,8 @@
     "url": "http://www.rubynation.org",
     "startDate": "2015-06-12",
     "endDate": "2015-06-13",
-    "city": "Washington",
-    "country": "DC",
+    "city": "Washington, DC",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubynation"
   },
   {
@@ -236,6 +238,7 @@
     "url": "http://www.reddotrubyconf.com",
     "startDate": "2015-06-04",
     "endDate": "2015-06-05",
+    "city": "Singapore",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
@@ -250,6 +253,7 @@
   },
   {
     "name": "RubyConf Kenya",
+    "url": "http://rubyconf.nairuby.org/2015",
     "startDate": "2015-05-08",
     "endDate": "2015-05-09",
     "city": "Nairobi",
@@ -270,8 +274,8 @@
     "url": "http://www.railsconf.com",
     "startDate": "2015-04-21",
     "endDate": "2015-04-23",
-    "city": "Atlanta",
-    "country": "GA",
+    "city": "Atlanta, GA",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/railsconf"
   },
   {
@@ -297,8 +301,8 @@
     "url": "http://www.ancientcityruby.com",
     "startDate": "2015-03-26",
     "endDate": "2015-03-27",
-    "city": "St. Augustine",
-    "country": "FL",
+    "city": "St. Augustine, FL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/ancientcityruby"
   },
   {
@@ -333,8 +337,8 @@
     "url": "http://mtnwestrubyconf.org",
     "startDate": "2015-03-09",
     "endDate": "2015-03-10",
-    "city": "Salt Lake City",
-    "country": "UT",
+    "city": "Salt Lake City, UT",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/mwrc"
   },
   {
@@ -348,10 +352,11 @@
   },
   {
     "name": "Ruby on Ales",
+    "url": "https://ruby.onales.com/",
     "startDate": "2015-03-05",
     "endDate": "2015-03-06",
-    "city": "Bend",
-    "country": "OR",
+    "city": "Bend, OR",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rbonales"
   },
   {

--- a/conferences/2016/ruby.json
+++ b/conferences/2016/ruby.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "RubyConf Taiwan",
+    "url": "https://2016.rubyconf.tw/",
     "startDate": "2016-12-02",
     "endDate": "2016-12-03",
     "city": "Taipei",
@@ -18,6 +19,7 @@
   },
   {
     "name": "Rail Israel",
+    "url": "https://railsisrael2016.events.co.il/home",
     "startDate": "2016-11-14",
     "endDate": "2016-11-15",
     "city": "Tel Aviv",
@@ -38,8 +40,8 @@
     "url": "http://keeprubyweird.com",
     "startDate": "2016-10-28",
     "endDate": "2016-10-28",
-    "city": "Austin",
-    "country": "TX",
+    "city": "Austin, TX",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/keeprubyweird"
   },
   {
@@ -71,6 +73,7 @@
   },
   {
     "name": "Conferencia Rails",
+    "url": "http://conferenciaror.es/",
     "startDate": "2016-10-14",
     "endDate": "2016-10-15",
     "city": "Madrid",
@@ -109,8 +112,8 @@
     "url": "http://www.windycityrails.org",
     "startDate": "2016-09-15",
     "endDate": "2016-09-16",
-    "city": "Chicago",
-    "country": "IL",
+    "city": "Chicago, IL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/windycityrails"
   },
   {
@@ -181,12 +184,13 @@
     "url": "http://goruco.com",
     "startDate": "2016-06-25",
     "endDate": "2016-06-25",
-    "city": "New York",
-    "country": "NY",
+    "city": "New York, NY",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/goruco"
   },
   {
     "name": "GrillRB",
+    "url": "https://grillrb.com/",
     "startDate": "2016-06-25",
     "endDate": "2016-06-26",
     "city": "Wrocław",
@@ -198,6 +202,7 @@
     "url": "http://www.reddotrubyconf.com",
     "startDate": "2016-06-23",
     "endDate": "2016-06-24",
+    "city": "Singapore",
     "country": "Singapore",
     "twitter": "https://twitter.com/reddotrubyconf"
   },
@@ -206,7 +211,8 @@
     "url": "http://www.nordicruby.org",
     "startDate": "2016-06-17",
     "endDate": "2016-06-19",
-    "country": "Stockholm",
+    "city": "Stockholm",
+    "country": "Sweden",
     "twitter": "https://twitter.com/nordicruby"
   },
   {
@@ -214,8 +220,8 @@
     "url": "http://www.rubyforgood.org",
     "startDate": "2016-06-16",
     "endDate": "2016-06-19",
-    "city": "Washington",
-    "country": "DC",
+    "city": "Washington, DC",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubyforgood"
   },
   {
@@ -232,8 +238,8 @@
     "url": "http://www.rubynation.org",
     "startDate": "2016-06-03",
     "endDate": "2016-06-04",
-    "city": "Washington",
-    "country": "DC",
+    "city": "Washington, DC",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/rubynation"
   },
   {
@@ -286,12 +292,13 @@
     "url": "http://www.ancientcityruby.com",
     "startDate": "2016-04-06",
     "endDate": "2016-04-08",
-    "city": "St. Augustine",
-    "country": "FL",
+    "city": "St. Augustine, FL",
+    "country": "U.S.A.",
     "twitter": "https://twitter.com/ancientcityruby"
   },
   {
     "name": "Ruby on Ales",
+    "url": "https://ruby.onales.com/",
     "startDate": "2016-03-31",
     "endDate": "2016-04-01",
     "city": "Bend",

--- a/conferences/2016/ux.json
+++ b/conferences/2016/ux.json
@@ -3,105 +3,129 @@
     "name": "Design Indaba",
     "url": "http://www.designindaba.com/tags/design-indaba-conference-2016",
     "startDate": "2016-02-17",
-    "endDate": "2016-02-19"
+    "endDate": "2016-02-19",
+    "city": "Cape Town",
+    "country": "South Africa"
   },
   {
     "name": "Interaction 17",
     "url": "http://interaction17.ixda.org",
     "startDate": "2016-02-04",
     "endDate": "2016-02-08",
-    "city": "NYC"
+    "city": "NYC",
+    "country": "U.S.A."
   },
   {
     "name": "ConveyUX",
     "url": "http://conveyux.com",
     "startDate": "2016-02-28",
     "endDate": "2016-03-02",
-    "city": "Seattle"
+    "city": "Seattle",
+    "country": "U.S.A."
   },
   {
     "name": "Intelligent Content",
     "url": "http://www.intelligentcontentconference.com",
     "startDate": "2016-03-28",
     "endDate": "2016-03-30",
-    "city": "Vegas, baby"
+    "city": "Las Vegas",
+    "country": "U.S.A."
   },
   {
     "name": "Cambridge Workshop on Universal Access and Assistive Tech",
     "url": "http://www-edc.eng.cam.ac.uk/cwuaat",
     "startDate": "2016-03-21",
-    "endDate": "2016-03-23"
+    "endDate": "2016-03-23",
+    "city": "Cambridge",
+    "country": "U.K."
   },
   {
     "name": "Customer Experience Conf",
     "url": "https://www.conference-board.org/conferences/conferencedetail.cfm?conferenceid=2774",
     "startDate": "2016-03-23",
-    "endDate": "2016-03-24"
+    "endDate": "2016-03-24",
+    "city": "New York",
+    "country": "U.S.A."
   },
   {
     "name": "UX Burlington",
     "url": "http://uxburlington.com",
     "startDate": "2016-04-29",
-    "endDate": "2016-04-29"
+    "endDate": "2016-04-29",
+    "city": "Burlington",
+    "country": "U.S.A."
   },
   {
     "name": "IA Summit ",
     "url": "http://www.iasummit.org",
     "startDate": "2016-03-22",
     "endDate": "2016-03-26",
-    "city": "Vancouver!"
+    "city": "Vancouver",
+    "country": "Canada"
   },
   {
     "name": "DIBIConference",
     "url": "http://www.dibiconference.com",
     "startDate": "2016-03-30",
-    "endDate": "2016-03-31"
+    "endDate": "2016-03-31",
+    "city": "Edinburgh",
+    "country": "U.K."
   },
   {
     "name": "Clarity - design systems conf",
     "url": "http://clarityconf.com",
     "startDate": "2016-03-31",
-    "endDate": "2016-04-01"
+    "endDate": "2016-04-01",
+    "city": "San Francisco",
+    "country": "U.S.A."
   },
   {
     "name": "WAQ",
     "url": "https://webaquebec.org",
     "startDate": "2016-04-04",
-    "endDate": "2016-04-06"
+    "endDate": "2016-04-06",
+    "city": "Québec",
+    "country": "Canada"
   },
   {
     "name": "How To Create Products Customers Love",
     "url": "http://svpg.com/how-to-create-products-customers-love-2",
     "startDate": "2016-04-11",
     "endDate": "2016-04-12",
-    "city": "Quebec City"
+    "city": "Quebec City",
+    "country": "Canada"
   },
   {
     "name": "Unite",
     "url": "https://unite.shopify.com",
     "startDate": "2016-04-20",
     "endDate": "2016-04-21",
-    "city": "San Fran"
+    "city": "San Francisco",
+    "country": "U.S.A."
   },
   {
     "name": "Write the Docs",
     "url": "http://www.writethedocs.org",
     "startDate": "2016-05-14",
     "endDate": "2016-05-16",
-    "city": "San Fran"
+    "city": "San Francisco",
+    "country": "U.S.A."
   },
   {
     "name": "Design Management Conference Europe",
     "url": "http://www.dmi.org/?Adam2016Overview",
     "startDate": "2016-05-23",
     "endDate": "2016-05-25",
-    "city": "Portland, OR"
+    "city": "Portland, OR",
+    "country": "U.S.A."
   },
   {
     "name": "Design Science Research in Information Systems and Technologies (DESRIST) 2016 Conference",
     "url": "https://desrist2016.wordpress.com",
     "startDate": "2016-05-24",
-    "endDate": "2016-05-25"
+    "endDate": "2016-05-25",
+    "city": "St. John’s",
+    "country": "Canada"
   },
   {
     "name": "UXPA",
@@ -116,268 +140,319 @@
     "url": "http://promo.rosenfeldmedia.com/euxsignup2017",
     "startDate": "2016-06-07",
     "endDate": "2016-06-09",
-    "city": "San Fran"
+    "city": "San Francisco",
+    "country": "U.S.A."
   },
   {
     "name": "Confab Central",
     "url": "http://confabevents.com",
     "startDate": "2016-06-07",
     "endDate": "2016-06-09",
-    "city": "Minneapolis"
+    "city": "Minneapolis",
+    "country": "U.S.A."
   },
   {
     "name": "UX Scotland",
-    "url": "http://uxscotland.net/2017",
+    "url": "http://uxscotland.net/2016",
     "startDate": "2016-06-07",
-    "endDate": "2016-06-09"
+    "endDate": "2016-06-09",
+    "city": "Edinburgh",
+    "country": "U.K."
   },
   {
     "name": "Collective",
     "url": "http://collectiveconf.com",
     "startDate": "2016-06-08",
-    "endDate": "2016-06-10"
+    "endDate": "2016-06-10",
+    "city": "Atlanta",
+    "country": "U.S.A.",
+    "twitter": "https://twitter.com/collectiveconf"
   },
   {
     "name": "UX Strat 2017",
     "url": "http://www.uxstrat.com/europe",
     "startDate": "2016-06-15",
     "endDate": "2016-06-18",
-    "city": "Amsterdam"
+    "city": "Amsterdam",
+    "country": "Netherlands"
   },
   {
     "name": "UXcamp Europe",
     "url": "http://www.uxcampeurope.org",
     "startDate": "2016-06-25",
-    "endDate": "2016-06-26"
+    "endDate": "2016-06-26",
+    "city": "Berlin",
+    "country": "Germany"
   },
   {
     "name": "Eyeo 2017",
     "url": "http://eyeofestival.com",
     "startDate": "2016-06-26",
     "endDate": "2016-06-29",
-    "city": "MINNEAPOLIS"
+    "city": "Minneapolis",
+    "country": "U.S.A."
   },
   {
     "name": "Design Research Society Conf",
     "url": "http://www.drs2016.org",
     "startDate": "2016-06-27",
     "endDate": "2016-06-30",
-    "city": "[not until 2018]"
+    "city": "Brighton",
+    "country": "U.K."
   },
   {
     "name": "LavaCon Dublin",
     "url": "http://lavacon.org/2016/dublin",
     "startDate": "2016-06-05",
-    "endDate": "2016-06-07"
+    "endDate": "2016-06-07",
+    "city": "Dublin",
+    "country": "Ireland"
   },
   {
     "name": "Internation Conference of Experience Design",
     "url": "http://ixdc.org/2016/en/index.php",
     "startDate": "2016-06-29",
-    "endDate": "2016-07-03"
+    "endDate": "2016-07-03",
+    "city": "Beijing",
+    "country": "China"
   },
   {
     "name": "What Design Can Do",
     "url": "http://www.whatdesigncando.com/amsterdam-2016",
     "startDate": "2016-06-30",
     "endDate": "2016-07-01",
-    "city": "Amsterdam"
+    "city": "Amsterdam",
+    "country": "Netherlands"
   },
   {
     "name": "Design and Content Conf",
     "url": "https://designcontentconf.com",
     "startDate": "2016-07-17",
     "endDate": "2016-07-19",
-    "city": "Vancouver"
+    "city": "Vancouver",
+    "country": "Canada"
   },
   {
     "name": "AHFE 2016 ",
     "url": "http://www.ahfe2016.org",
     "startDate": "2016-07-27",
-    "endDate": "2016-07-31"
+    "endDate": "2016-07-31",
+    "city": "Orlando",
+    "country": "U.S.A."
   },
   {
     "name": "UX Week",
     "url": "http://uxweek.com",
     "startDate": "2016-08-29",
     "endDate": "2016-09-01",
-    "city": "San Fran"
+    "city": "San Francisco",
+    "country": "U.S.A."
   },
   {
     "name": "The Conference",
     "url": "http://2017.theconference.se",
     "startDate": "2016-09-04",
     "endDate": "2016-09-05",
-    "city": "Malmo, Sweden"
+    "city": "Malmo",
+    "country": "Sweden"
   },
   {
     "name": "MobileHCI",
     "url": "http://mobilehci.acm.org/2017",
     "startDate": "2016-09-04",
     "endDate": "2016-09-07",
-    "city": "Vienna, Austria"
+    "city": "Vienna",
+    "country": "Austria"
   },
   {
     "name": "MOBX (Mobile UX)",
     "url": "https://2017.mobxcon.com",
     "startDate": "2016-09-07",
     "endDate": "2016-09-08",
-    "city": "Berlin, Germany"
+    "city": "Berlin",
+    "country": "Germany"
   },
   {
     "name": "Brand New Conference",
     "url": "http://www.underconsideration.com/brandnewconference",
     "startDate": "2016-09-14",
     "endDate": "2016-09-15",
-    "city": "Chicago"
+    "city": "Chicago",
+    "country": "U.S.A."
   },
   {
     "name": "UX Strat USA",
     "url": "http://www.uxstrat.com/usa",
     "startDate": "2016-09-18",
     "endDate": "2016-09-20",
-    "city": "Boulder, CO"
+    "city": "Boulder, CO",
+    "country": "U.S.A."
   },
   {
     "name": "Confab Intensive",
     "url": "http://confabevents.com/events/intensive/2016",
     "startDate": "2016-09-11",
     "endDate": "2016-09-13",
-    "city": "Denver, CO"
+    "city": "Denver, CO",
+    "country": "U.S.A."
   },
   {
     "name": "EuroIA",
     "url": "http://www.euroia.org",
     "startDate": "2016-09-28",
     "endDate": "2016-09-30",
-    "city": "Stockholm"
+    "city": "Stockholm",
+    "country": "Sweden"
   },
   {
     "name": "Write the Docs Europe",
     "url": "http://www.writethedocs.org/conf/eu/2016/",
     "startDate": "2016-09-18",
     "endDate": "2016-09-20",
-    "city": "Prague"
+    "city": "Prague",
+    "country": "Czech Republic"
   },
   {
     "name": "Design Leadership Conference",
     "url": "http://www.dmi.org/?page=Conferences",
     "startDate": "2016-09-24",
     "endDate": "2016-09-26",
-    "city": "Minneapolis"
+    "city": "Minneapolis",
+    "country": "U.S.A."
   },
   {
     "name": "Fluxible ",
     "url": "http://www.fluxible.ca",
     "startDate": "2016-09-18",
     "endDate": "2016-09-24",
-    "city": "Waterloo, ON"
+    "city": "Waterloo, ON",
+    "country": "U.S.A."
   },
   {
     "name": "Design Matters '17",
     "url": "https://designmatters.io",
     "startDate": "2016-09-27",
     "endDate": "2016-09-28",
-    "city": "Copenhagen, Denmark"
+    "city": "Copenhagen",
+    "country": "Denmark"
   },
   {
     "name": "Interact",
     "url": "https://www.interact2017.org",
     "startDate": "2016-09-25",
     "endDate": "2016-09-29",
-    "city": "Mumbai, India"
+    "city": "Mumbai",
+    "country": "India"
   },
   {
     "name": "Content Strategy Forum",
     "url": "http://contentark.com.au/content-strategy-forum-2016",
     "startDate": "2016-10-05",
-    "endDate": "2016-10-07"
+    "endDate": "2016-10-07",
+    "city": "Melbourne",
+    "country": "Australia"
   },
   {
     "name": "GIANT Conference",
     "url": "http://www.giantconf.com/details",
     "startDate": "2016-10-17",
-    "endDate": "2016-10-19"
+    "endDate": "2016-10-19",
+    "city": "Charlotte, NC",
+    "country": "U.S.A."
   },
   {
     "name": "SmashingConf",
     "url": "https://smashingconf.com/barcelona-2017",
     "startDate": "2016-10-17",
     "endDate": "2016-10-18",
-    "city": "Barcelona, Spain"
+    "city": "Barcelona",
+    "country": "Spain"
   },
   {
     "name": "EPIC Conf",
     "url": "https://www.epicpeople.org",
     "startDate": "2016-10-22",
     "endDate": "2016-10-25",
-    "city": "Montreal!"
+    "city": "Montreal",
+    "country": "Canada"
   },
   {
     "name": "Design Thinkers",
     "url": "https://www.designthinkers.com/News/2017/DesignThinkers-Montreal-2017.aspx",
     "startDate": "2016-10-19",
     "endDate": "2016-10-20",
-    "city": "Montreal"
+    "city": "Montreal",
+    "country": "Canada"
   },
   {
     "name": "LavaCon",
     "url": "https://lavacon.org/2017/portland",
     "startDate": "2016-11-05",
     "endDate": "2016-11-08",
-    "city": "Portland, Oregon"
+    "city": "Portland, Oregon",
+    "country": "U.S.A."
   },
   {
     "name": "Productized",
     "url": "http://www.productized.co",
     "startDate": "2016-10-19",
     "endDate": "2016-10-21",
-    "city": "Lisbon, Portugal"
+    "city": "Lisbon",
+    "country": "Portugal"
   },
   {
     "name": "Pop Tech",
     "url": "http://poptech.org/conferences",
     "startDate": "2016-10-19",
     "endDate": "2016-10-21",
-    "city": "Camden, Maine"
+    "city": "Camden, Maine",
+    "country": "U.S.A."
   },
   {
     "name": "Service Design Network Conf",
     "url": "http://www.service-design-network.org/conferences",
     "startDate": "2016-10-27",
-    "endDate": "2016-10-28"
+    "endDate": "2016-10-28",
+    "city": "Amsterdam",
+    "country": "Netherlands"
   },
   {
     "name": "Beyond Tellerrand",
     "url": "https://beyondtellerrand.com",
     "startDate": "2016-11-06",
     "endDate": "2016-11-08",
-    "city": "Berlin, Germany"
+    "city": "Berlin",
+    "country": "Germany"
   },
   {
     "name": "CanUX",
     "url": "http://canux.io",
     "startDate": "2016-11-03",
     "endDate": "2016-11-05",
-    "city": "Ottawa"
+    "city": "Ottawa",
+    "country": "Canada"
   },
   {
     "name": "Gather North",
     "url": "https://gathernorth.com",
     "startDate": "2016-11-17",
     "endDate": "2016-11-19",
-    "city": "Montebello, Quebec"
+    "city": "Montebello, Quebec",
+    "country": "Canada"
   },
   {
     "name": "Taxonomy boot camp",
     "url": "http://www.taxonomybootcamp.com/2017/default.aspx",
     "startDate": "2016-11-06",
     "endDate": "2016-11-07",
-    "city": "Washington, DC"
+    "city": "Washington, DC",
+    "country": "U.S.A."
   },
   {
     "name": "Delight",
     "url": "http://delight.us/conference",
-    "startDate": "2016-12-08"
+    "startDate": "2016-12-08",
+    "city": "Portland",
+    "country": "U.S.A."
   }
 ]

--- a/conferences/2017/android.json
+++ b/conferences/2017/android.json
@@ -81,7 +81,7 @@
     "name": "AppDevCon",
     "url": "http://www.appdevcon.nl",
     "city": "Amsterdam",
-    "country": "NL",
+    "country": "Netherlands",
     "startDate": "2017-03-16",
     "endDate": "2017-03-17",
     "cfpStart": "2016-11-26",
@@ -99,8 +99,8 @@
   {
     "name": "Droid Knights",
     "url": "https://droidknights.github.io/2017",
-    "city": "Seoul, Sout",
-    "country": "Korea",
+    "city": "Seoul",
+    "country": "South Korea",
     "startDate": "2017-03-25",
     "endDate": "2017-03-25"
   },
@@ -124,7 +124,7 @@
     "name": "Droidcon",
     "url": "http://it.droidcon.com/2017",
     "city": "Turin",
-    "country": "IT",
+    "country": "Italy",
     "startDate": "2017-04-06",
     "endDate": "2017-04-07",
     "cfpStart": "2016-10-14",
@@ -164,7 +164,7 @@
     "name": "Droidcon",
     "url": "https://ticketbox.vn/event/droidcon-vietnam-64153",
     "city": "Ho Chi Minh City",
-    "country": "VN",
+    "country": "Vietnam",
     "startDate": "2017-04-15",
     "endDate": "2017-04-16"
   },
@@ -210,7 +210,7 @@
     "name": "Mobius",
     "url": "http://mobiusconf.com/en",
     "city": "Saint Petersburg",
-    "country": "RU",
+    "country": "Russia",
     "startDate": "2017-04-21",
     "endDate": "2017-04-22",
     "cfpStart": "2016-08-01",
@@ -358,8 +358,8 @@
   {
     "name": "APPFORUM Europe",
     "url": "https://www.zebra.com/us/en/events/appforum/europe.html",
-    "city": "Prague, Czec",
-    "country": "Republic",
+    "city": "Prague",
+    "country": "Czech Republic",
     "startDate": "2017-06-14",
     "endDate": "2017-06-16"
   },
@@ -452,8 +452,8 @@
   {
     "name": "Android Summit",
     "url": "http://androidsummit.org",
-    "city": "McLean",
-    "country": "VA",
+    "city": "McLean, VA",
+    "country": "U.S.A.",
     "startDate": "2017-08-24",
     "endDate": "2017-08-25",
     "cfpStart": "2017-03-21",

--- a/conferences/2017/android.json
+++ b/conferences/2017/android.json
@@ -40,8 +40,8 @@
   {
     "name": "Mobile+Web DevCon",
     "url": "http://mobilewebdevconference.com/san-francisco-2017",
-    "city": "San Francisco",
-    "country": "CA",
+    "city": "San Francisco, CA",
+    "country": "U.S.A.",
     "startDate": "2017-03-01",
     "endDate": "2017-03-03",
     "cfpStart": "2016-11-02",
@@ -198,8 +198,8 @@
   {
     "name": "Chicago Roboto",
     "url": "http://chicagoroboto.com",
-    "city": "Chicago",
-    "country": "IL",
+    "city": "Chicago, IL",
+    "country": "U.S.A.",
     "startDate": "2017-04-20",
     "endDate": "2017-04-21",
     "cfpStart": "2016-11-08",

--- a/conferences/2017/ruby.json
+++ b/conferences/2017/ruby.json
@@ -121,6 +121,7 @@
     "url": "http://www.reddotrubyconf.com",
     "startDate": "2017-06-22",
     "endDate": "2017-06-23",
+    "city": "Singapore",
     "country": "Singapore",
     "twitter": "@reddotrubyconf"
   },

--- a/conferences/2017/ux.json
+++ b/conferences/2017/ux.json
@@ -95,7 +95,7 @@
     "url": "https://unite.shopify.com",
     "startDate": "2017-04-20",
     "endDate": "2017-04-21",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A."
   },
   {
@@ -124,7 +124,7 @@
     "url": "http://www.writethedocs.org",
     "startDate": "2017-05-14",
     "endDate": "2017-05-16",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A."
   },
   {
@@ -180,7 +180,7 @@
     "url": "http://uxpa.github.io",
     "startDate": "2017-06-05",
     "endDate": "2017-06-08",
-    "city": "St John's, NL",
+    "city": "St. John’s, NL",
     "country": "Canada"
   },
   {
@@ -196,7 +196,7 @@
     "url": "http://promo.rosenfeldmedia.com/euxsignup2017",
     "startDate": "2017-06-07",
     "endDate": "2017-06-09",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A."
   },
   {
@@ -406,7 +406,7 @@
     "url": "http://uxweek.com",
     "startDate": "2017-08-29",
     "endDate": "2017-09-01",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A."
   },
   {

--- a/conferences/2017/ux.json
+++ b/conferences/2017/ux.json
@@ -79,7 +79,7 @@
     "url": "https://webaquebec.org",
     "startDate": "2017-04-04",
     "endDate": "2017-04-06",
-    "city": "Quebec",
+    "city": "Quebec City",
     "country": "Canada"
   },
   {
@@ -373,7 +373,7 @@
     "url": "https://www.interact2017.org",
     "startDate": "2017-09-25",
     "endDate": "2017-09-29",
-    "city": "Mumbai, India",
+    "city": "Mumbai",
     "country": "India"
   },
   {
@@ -381,7 +381,7 @@
     "url": "https://designmatters.io",
     "startDate": "2017-09-27",
     "endDate": "2017-09-28",
-    "city": "Copenhagen, Denmark",
+    "city": "Copenhagen",
     "country": "Denmark"
   },
   {
@@ -619,7 +619,7 @@
     "url": "http://www.slush.org",
     "startDate": "2017-11-30",
     "endDate": "2017-12-01",
-    "city": "HELSINKI",
+    "city": "Helsinki",
     "country": "Finland",
     "twitter": "@SlushHQ"
   }

--- a/conferences/2018/devops.json
+++ b/conferences/2018/devops.json
@@ -202,7 +202,7 @@
     "url": "https://2018.dockercon.com",
     "startDate": "2018-06-12",
     "endDate": "2018-06-15",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A.",
     "twitter": "@DockerCon"
   },

--- a/conferences/2018/dotnet.json
+++ b/conferences/2018/dotnet.json
@@ -5,7 +5,7 @@
     "startDate": "2018-05-02",
     "endDate": "2018-05-04",
     "city": "Seoul",
-    "country": "Korea"
+    "country": "South Korea"
   },
   {
     "name": "Unite Tokyo",

--- a/conferences/2018/tech-comm.json
+++ b/conferences/2018/tech-comm.json
@@ -108,7 +108,7 @@
     "url": "http://www.writethedocs.org/conf/cincinnati/2018/",
     "startDate": "2018-08-18",
     "endDate": "2018-08-22",
-    "city": "Cincinatti, OH",
+    "city": "Cincinnati, OH",
     "country": "U.S.A.",
     "twitter": "@writethedocs",
     "cfpUrl": "http://www.writethedocs.org/conf/cincinnati/2018/cfp/",

--- a/conferences/2018/ux.json
+++ b/conferences/2018/ux.json
@@ -431,7 +431,7 @@
     "url": "http://uxscotland.net/2018",
     "startDate": "2018-06-13",
     "endDate": "2018-06-15",
-    "city": "Edimburgh",
+    "city": "Edinburgh",
     "country": "U.K."
   },
   {
@@ -456,7 +456,7 @@
     "url": "https://smashingconf.com/toronto-2018",
     "startDate": "2018-06-26",
     "endDate": "2018-06-27",
-    "city": "Tonronto",
+    "city": "Toronto",
     "country": "Canada",
     "twitter": "@smashingconf"
   },

--- a/conferences/2018/ux.json
+++ b/conferences/2018/ux.json
@@ -298,7 +298,7 @@
     "url": "https://conference.awwwards.com/san-francisco",
     "startDate": "2018-05-10",
     "endDate": "2018-05-11",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A."
   },
   {
@@ -512,7 +512,7 @@
     "url": "http://uxweek.com",
     "startDate": "2018-08-21",
     "endDate": "2018-08-24",
-    "city": "San Fransisco",
+    "city": "San Francisco",
     "country": "U.S.A.",
     "twitter": "@AdaptivePath"
   },


### PR DESCRIPTION
Hi again,

This pull request ensures that all conferences have a country and a city property. Through geocoding the city names I noticed some spelling mistakes. To pass the tests I also included a conference url where missing.

Changes include:

* fixed state names as country: eg. `"city": "San Diego", "country": "CA"` to `"city": "San Diego, CA": "country": "U.S.A."`
* "San Fransisco" to "San Francisco"
* "Cincinatti" to "Cincinnati"
* `"city": "<city>, <county>` to `"city": <city>, "country": <country>`