### PR TITLE
Remove Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 10.8.0


### PR DESCRIPTION
We currently use both TravisCI and CircleCI, and both are good for our requirements
Choose TravisCI as it's more popular, has more features and was first in the market
Example comparison: https://hackernoon.com/ci-41a1c2bd95f5