### PR TITLE
Ignore webpack dependency updates in greenkeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,13 @@
   },
   "engines": {
     "node": "10.8.0"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "ts-loader",
+      "webpack",
+      "webpack-dev-server",
+      "webpack-manifest-plugin"
+    ]
   }
 }


### PR DESCRIPTION
Original PR https://github.com/tech-conferences/confs.tech/pull/394
Some dependencies were manually updated in [commit](https://github.com/tech-conferences/confs.tech/pull/394/files/59762f267376a139712e4e000454cd20cc51d655..55c875df7e9ad376a42152dd53a525afa820b4e6) which need to be explicitly ignored in greenkeeper settings

Greenkeeper documentation on how to ignore dependencies https://greenkeeper.io/docs#ignoring-dependencies