### PR TITLE
Fix topic list display on Suggest a Conf w Firefox

### DIFF
--- a/src/components/ConferenceNewPage/ConferenceNewPage.tsx
+++ b/src/components/ConferenceNewPage/ConferenceNewPage.tsx
@@ -245,7 +245,7 @@ export default class ConferenceNewPage extends Component<Props> {
               onChange={this.handleFieldChange}
             >
               {SORTED_TOPICS_KEYS.map((value: string) => (
-                <option key={value} value={value} label={TOPICS[value]} />
+                <option key={value} value={value}>{TOPICS[value]}</option>
               ))}
             </select>
           </InputGroup>


### PR DESCRIPTION
As noted in the MDN and detailed in the (gulp) 17 year old bugzilla entry - https://bugzilla.mozilla.org/show_bug.cgi?id=40545, Firefox doesn't adequately display option elements with a label and no content. Instead there is a ~20px wide list of blank entries which is quite unuseable for Firefox users.