### PR TITLE
Add search ability

### DIFF
--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -25,6 +25,7 @@ import GithubStar from '../GithubStar';
 import Heading from '../Heading';
 import ConferenceList from '../ConferenceList';
 import {TOPICS} from '../config';
+import Search from '../Search'
 
 const QUERY_SEPARATOR = '+';
 const CURRENT_YEAR = new Date().getFullYear();
@@ -174,6 +175,7 @@ class ConferencePage extends Component<ComposedProps, State> {
           indexName={'prod_conferences'}
         >
           <Configure hitsPerPage={hitsPerPage} filters={this.algoliaFilter()} />
+          <Search />
           <RefinementList
             limit={20}
             attribute="topics"

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -1,0 +1,13 @@
+@import '../style/foundation/spacing';
+@import '../style/foundation/typography';
+@import '../style/foundation/colors';
+
+.Search {
+  margin-bottom: 2rem;
+
+  :global {
+    .ais-SearchBox-form {
+      display: flex;
+    }
+  } 
+}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable */
+import React from 'react';
+import { SearchBox } from 'react-instantsearch/dom';
+import styles from './Search.scss';
+
+export default function Search() {
+  return (
+    <div className={styles.Search}>
+      <SearchBox />
+    </div>
+  );
+}

--- a/src/components/Search/index.ts
+++ b/src/components/Search/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Search';


### PR DESCRIPTION
If I am looking for a particular conference but I don't know when it is happening, I have to choose a category and scan the list to find it.

There is potential for duplicate entries if a conference is added to more than one json topic file. Ex: SmashingConf is listed in `CSS`, `UX`, and `JavaScript` json files. This may warrant the re-architecture of the topics.

Will likely need styles for the buttons, but I'll leave that up to your discretion.