### PR TITLE
Increase initial conference list from 150 to 600

### DIFF
--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -47,7 +47,7 @@ type ComposedProps = Props & any;
 
 class ConferencePage extends Component<ComposedProps, State> {
   state: State = {
-    hitsPerPage: 150,
+    hitsPerPage: 600,
     sortBy: 'startDate',
     showPast: false,
   };


### PR DESCRIPTION
I would like to increase the amount of conferences which are initially loaded from 150 to 600. Currently you can just see conferences for the next 2 months. The load more button is also not very large and the page doesn't load more conferences when you hit the bottom of the page. 

I think increasing the initial load would be an acceptable quick fix. The payload from Algolia would be about 100KB (currently the payload is about 25KB). That shouldn't impact the performance too much. Most of the content Algolia sends is nevertheless not used.