### PR TITLE
Conf search

### DIFF
--- a/src/components/ConferenceList/ConferenceList.scss
+++ b/src/components/ConferenceList/ConferenceList.scss
@@ -22,3 +22,7 @@
     margin-bottom: 0.5em;
   }
 }
+
+.NoResults {
+  text-align: center;
+}

--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -25,6 +25,7 @@ import GithubStar from '../GithubStar';
 import Heading from '../Heading';
 import ConferenceList from '../ConferenceList';
 import {TOPICS} from '../config';
+import Search from '../Search'
 
 const QUERY_SEPARATOR = '+';
 const CURRENT_YEAR = new Date().getFullYear();
@@ -188,6 +189,8 @@ class ConferencePage extends Component<ComposedProps, State> {
             transformItems={transformCountryRefinements}
             defaultRefinement={countries}
           />
+
+          <Search />
 
           <CurrentRefinements transformItems={transformCurrentRefinements} />
 

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -1,0 +1,18 @@
+@import '../style/foundation/spacing';
+@import '../style/foundation/typography';
+@import '../style/foundation/colors';
+
+.Search {
+  margin-bottom: spacing();
+}
+
+:global {
+  .ais-SearchBox-form {
+    display: flex;
+  }
+
+  .ais-SearchBox-submit,
+  .ais-SearchBox-reset {
+    display: none;
+  }
+}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { SearchBox } from 'react-instantsearch/dom';
+import styles from './Search.scss';
+
+export default function Search() {
+  return (
+    <div className={styles.Search}>
+      <SearchBox />
+    </div>
+  );
+}

--- a/src/components/Search/index.ts
+++ b/src/components/Search/index.ts
@@ -1,0 +1,1 @@
+export {default} from './Search';


### PR DESCRIPTION
Follow up of https://github.com/tech-conferences/confs.tech/pull/425

![Search](https://user-images.githubusercontent.com/445045/56083481-8cab8d80-5df3-11e9-88e7-ec83fe4e3b3e.gif)

@trivikr @prigara @cgrail What do you think about that?

Also: We can probably find a better placeholder than `Search here...`. I'm open to suggestions.