### PR TITLE
Update tech-comm topic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Some of the conferences have been pulled from other projects:
 - [See all Design / UX conferences](https://confs.tech/ux)
 - [See all Ruby conferences](https://confs.tech/ruby)
 - [See all iOS conferences](https://confs.tech/ios)
-- [See all Technical communication conferences](https://confs.tech/tech-comm)
+- [See all Content strategy conferences](https://confs.tech/tech-comm)
 - [See all Data conferences](https://confs.tech/data)
 - [See all Dev Ops conferences](https://confs.tech/devops)
 - [See all Android conferences](https://confs.tech/android)

--- a/src/components/config/index.js
+++ b/src/components/config/index.js
@@ -1,7 +1,7 @@
 export const CURRENT_YEAR = (new Date()).getFullYear() - 1;
 
 export const TOPICS = {
-  'tech-comm': 'Technical communication',
+  'tech-comm': 'Content strategy',
   android: 'Android',
   clojure: 'Clojure',
   cpp: 'C++',


### PR DESCRIPTION
Changed `Technical communication` to `Content Strategy` to better fit the industry.