### PR TITLE
Added a toggle button for newsletter banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "promise": "8.0.2",
     "qs": "^6.5.2",
     "react": "^16.2.0",
-    "react-cookie": "^3.0.4",
     "react-datepicker": "^1.2.1",
     "react-dev-utils": "^5.0.2",
     "react-dom": "^16.2.0",

--- a/src/components/ConferencePage/ConferencePage.scss
+++ b/src/components/ConferencePage/ConferencePage.scss
@@ -19,3 +19,9 @@
   font-weight: 600;
   @include link--hover();
 }
+
+.topLinks {
+  a {
+    margin-right: spacing(loose);
+  }
+}

--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -41,6 +41,7 @@ interface State {
   hitsPerPage: number;
   sortBy: string;
   showPast: boolean;
+  showNewsletterBanner: boolean;
   refinementList?: any;
 }
 
@@ -51,6 +52,7 @@ class ConferencePage extends Component<ComposedProps, State> {
     hitsPerPage: 600,
     sortBy: 'startDate',
     showPast: false,
+    showNewsletterBanner: false,
   };
 
   togglePast = () => {
@@ -127,8 +129,12 @@ class ConferencePage extends Component<ComposedProps, State> {
     });
   };
 
+  toggleNewsletter = () => {
+    this.setState({showNewsletterBanner: !this.state.showNewsletterBanner})
+  }
+
   render() {
-    const {showPast, sortBy, hitsPerPage} = this.state;
+    const {showPast, sortBy, hitsPerPage, showNewsletterBanner} = this.state;
     const {
       showCFP,
       match: {
@@ -194,11 +200,21 @@ class ConferencePage extends Component<ComposedProps, State> {
 
           <CurrentRefinements transformItems={transformCurrentRefinements} />
 
-          <p>
+          <p className={styles.topLinks}>
             <Link url={getCfpUrl(showCFP)}>
-              {showCFP ? 'Hide Call for Papers' : 'See Call for Papers'}
+              {showCFP ? 'Hide Call for Papers' : 'Call for Papers'}
+            </Link>
+
+            <Link onClick={this.toggleNewsletter}>
+              Newsletter
+            </Link>
+
+            <Link url="https://twitter.com/ConfsTech/" external>
+              Twitter
             </Link>
           </p>
+
+          {showNewsletterBanner && <StayTuned topic={getFirstTopic(topics)} />}
 
           {showCFP && (
             <CfpHeader
@@ -208,7 +224,6 @@ class ConferencePage extends Component<ComposedProps, State> {
           )}
 
           <ScrollToConference hash={location.hash} />
-          <StayTuned topic={getFirstTopic(topics)} />
           <ConferenceList
             onLoadMore={this.loadMore}
             sortBy={sortBy}

--- a/src/components/StayTuned/StayTuned.scss
+++ b/src/components/StayTuned/StayTuned.scss
@@ -45,7 +45,7 @@
 }
 
 .EmailInput {
-  max-width: 15em;
+  max-width: 20em;
   border-right: none;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;

--- a/src/components/StayTuned/StayTuned.tsx
+++ b/src/components/StayTuned/StayTuned.tsx
@@ -1,12 +1,9 @@
 import React, {PureComponent, ComponentType} from 'react';
 import classNames from 'classnames';
-import {withCookies, ReactCookieProps} from 'react-cookie';
 
-import Link from '../Link';
 import Heading from '../Heading';
 import styles from './StayTuned.scss';
 
-const DISMISSED_COOKIE = 'dismissed-stay-tuned';
 
 interface Props {
   topic: string;
@@ -14,31 +11,22 @@ interface Props {
 
 interface State {
   gdprChecked: boolean;
-  closed: boolean;
 }
-type ComposedProps = Props & ReactCookieProps;
+type ComposedProps = Props;
 
 class StayTuned extends PureComponent<ComposedProps, State> {
   state: State = {
-    gdprChecked: false,
-    closed: false,
+    gdprChecked: false
   };
 
   render() {
-    const {cookies, topic} = this.props;
-    const {gdprChecked, closed} = this.state;
-    if (cookies && cookies.get(DISMISSED_COOKIE)) {
-      return null;
-    }
-
+    const {topic} = this.props;
+    const {gdprChecked} = this.state;
     return (
-      <div className={classNames(styles.StayTuned, closed && styles.hidden)}>
+      <div className={classNames(styles.StayTuned)}>
         <Heading element="h4" level={4}>
           Stay tuned!
         </Heading>
-        <div className={styles.Close} onClick={this.close}>
-          <Link button>Close</Link>
-        </div>
         <div className={styles.Content}>
           <form
             action="https://tech.us19.list-manage.com/subscribe/post?u=246492d8cf0efc8c4ec6a9a60&amp;id=84b8d4723e"
@@ -96,9 +84,6 @@ class StayTuned extends PureComponent<ComposedProps, State> {
               </label>
             </div>
           </form>
-          <Link url="https://twitter.com/ConfsTech/" external>
-            Or follow us on Twitter
-          </Link>
         </div>
       </div>
     );
@@ -110,15 +95,6 @@ class StayTuned extends PureComponent<ComposedProps, State> {
     });
   };
 
-  private close = () => {
-    const {cookies} = this.props;
-    if (cookies) {
-      cookies.set(DISMISSED_COOKIE, true, {path: '/'});
-    }
-    this.setState({
-      closed: true,
-    });
-  };
 }
 
-export default withCookies(StayTuned) as ComponentType<Props>;
+export default StayTuned as ComponentType<Props>;


### PR DESCRIPTION
- I've hidden the Newsletter banner by default. 
- I've removed the `close` button from the banner since the Newsletter link is now just a toggle
- I've put a Twitter link next to the Newsletter link instead of having it inside the banner

Here's a gif:

![Jun-30-2019 12-30-02](https://user-images.githubusercontent.com/445045/60399483-e9852d00-9b32-11e9-807f-da17d8029fba.gif)

cc @prigara @trivikr 