### PR TITLE
Add product and leadership as a topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ Some of the conferences have been pulled from other projects:
 - [See all GraphQL conferences](https://confs.tech/graphql)
 - [See all networking events](https://confs.tech/networking)
 - [See all Closure conferences](https://confs.tech/clojure)
+- [See all Product conferences](https://confs.tech/product)
 - [See general conferences](https://confs.tech/general)

--- a/README.md
+++ b/README.md
@@ -78,4 +78,5 @@ Some of the conferences have been pulled from other projects:
 - [See all networking events](https://confs.tech/networking)
 - [See all Closure conferences](https://confs.tech/clojure)
 - [See all Product conferences](https://confs.tech/product)
+- [See all Leadership conferences](https://confs.tech/product)
 - [See general conferences](https://confs.tech/general)

--- a/src/components/config/index.js
+++ b/src/components/config/index.js
@@ -26,5 +26,6 @@ export const TOPICS = {
   security: 'Security',
   typescript: 'TypeScript',
   elm: 'Elm',
+  product: 'Product',
   ux: 'Design / UX',
 };

--- a/src/components/config/index.js
+++ b/src/components/config/index.js
@@ -27,5 +27,6 @@ export const TOPICS = {
   typescript: 'TypeScript',
   elm: 'Elm',
   product: 'Product',
+  leadership: 'Leadership',
   ux: 'Design / UX',
 };


### PR DESCRIPTION
@trivikr @prigara @cgrail are you onboard with adding _Product_ as a topic? I think it’s close enough to technologies that it would make sense to have it. 

I am thinking to do the same for _Leadership_ as well if you are onboard.