### PR TITLE
image algolia fix in footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -52,7 +52,7 @@ export default function Footer({showCFP, togglePast, showPast, cfpUrl}: Props) {
       <p>
         <img
           alt="Sponsor: Search by Algolia"
-          src="./search-by-algolia.svg"
+          src="/search-by-algolia.svg"
           height="20"
         />
       </p>


### PR DESCRIPTION
After selecting at least one technology and one country, and if you then refresh the page, the algolia sponsor image all the way at the bottom is broken. This should be fixed now. 