### PR TITLE
Only use named exports of react-helmet

### DIFF
--- a/src/components/Pages/Structure.tsx
+++ b/src/components/Pages/Structure.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Helmet from 'react-helmet';
+import {Helmet} from 'react-helmet';
 import Favicon from 'react-favicon';
 
 import styles from './Structure.scss';


### PR DESCRIPTION
The default export will be removed in react-helmet@6.0.0.

The corresponding type definition is currently missing in @types/react-helmet@5.0.11.
See also DefinitelyTyped/DefinitelyTyped#39094.

This is causing to the following error.

    TS2604: JSX element type 'Helmet' does not have any construct or call signatures.