### PR TITLE
Updated website description and texts on the submission page

### DIFF
--- a/src/components/ConferenceNewPage/ConferenceNewPage.tsx
+++ b/src/components/ConferenceNewPage/ConferenceNewPage.tsx
@@ -199,7 +199,7 @@ export default class ConferenceNewPage extends Component<Props> {
             @ConfsTech
           </Link>
           <br />
-          Find your submission and track its progress on{' '}
+          Find your submission and track its status on{' '}
           <Link
             external
             url="https://github.com/tech-conferences/conference-data/pulls"
@@ -460,16 +460,18 @@ export default class ConferenceNewPage extends Component<Props> {
         </Helmet>
         <Heading element="h1">Add a new conference</Heading>
         {!submitted && (
-          <p>
-            This will create a{' '}
+            <div>
+              <p>Confs.tech is focused on conferences on software development and related topics, such as product management, UX, and AI.</p>
+              <p>Know a conference on one of these topics? Feel free to submit it using this form!</p>
+              <p>This will create a{' '}
             <Link
               external
               url="https://github.com/tech-conferences/conference-data/pulls"
             >
               pull request on GitHub
             </Link>
-            . Our team will review it as soon as possible!
-          </p>
+                {' '}where you can also add additional comments and track submission status. Our team will review your request as soon as possible!</p>
+          </div>
         )}
         {submitted ? this.submitted() : this.form()}
       </div>

--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -168,7 +168,7 @@ class ConferencePage extends Component<ComposedProps, State> {
             </h1>
             <Heading element="p">Find your next tech conference</Heading>
             <Heading element="h2" level="sub">
-              Open-source and crowd-sourced conference website
+              Open-source and crowd-sourced list of conferences around software development
             </Heading>
           </div>
           <GithubStar />

--- a/src/components/Pages/Structure.tsx
+++ b/src/components/Pages/Structure.tsx
@@ -27,7 +27,7 @@ export default function Structure({children, title}: Props) {
             <Link routed url="/">
               Back to the conferences
             </Link>
-            {/* Open-source and crowd-sourced conference website */}
+            {/* Open-source and crowd-sourced list of conferences around software development */}
           </Heading>
         </div>
         <div>


### PR DESCRIPTION
We keep getting many submissions for events not related to software development that we eventually close without merging.
I think we can better communicate the scope of confs.tech on the main page and on the submission page so I've updated the texts. Please have a look and let me know what you think!