### PR TITLE
Show all past conferences

### DIFF
--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -30,7 +30,6 @@ import Search from '../Search'
 const QUERY_SEPARATOR = '+';
 const CURRENT_YEAR = new Date().getFullYear();
 const TODAY = Math.round(new Date().getTime() / 1000);
-const ONE_YEAR = 365 * 24 * 60 * 60;
 
 interface Props {
   showCFP: boolean;
@@ -115,7 +114,7 @@ class ConferencePage extends Component<ComposedProps, State> {
     const {showPast} = this.state;
     const {showCFP} = this.props;
     let filters = showPast
-      ? `startDateUnix>${TODAY - ONE_YEAR}`
+      ? `startDateUnix<${TODAY}`
       : `startDateUnix>${TODAY}`;
     if (showCFP) {
       filters += String(` AND cfpEndDateUnix>${TODAY}`);


### PR DESCRIPTION
Couldn't find a way to display all past conferences, looks like they're currently limited to one year. Is there a reason for this? On the performance side it seems fine after the change.