### PR TITLE
Move search bar up

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["plugin:shopify/react", "plugin:jsx-a11y/recommended", "prettier"],
   "plugins": ["jsx-a11y"],
   "rules": {
+    "react/jsx-filename-extension": ["jsx", "tsx"],
     "jsx-a11y/no-onchange": "off",
     "sort-class-members/sort-class-members": "off",
     "react/prop-types": "off",

--- a/src/components/ConferencePage/ConferencePage.tsx
+++ b/src/components/ConferencePage/ConferencePage.tsx
@@ -179,9 +179,12 @@ class ConferencePage extends Component<ComposedProps, State> {
           appId={process.env.ALGOLIA_APPLICATION_ID}
           apiKey={process.env.ALGOLIA_API_KEY}
           onSearchStateChange={this.onSearchStateChange}
-          indexName={'prod_conferences'}
+          indexName='prod_conferences'
         >
           <Configure hitsPerPage={hitsPerPage} filters={this.algoliaFilter()} />
+
+          <Search />
+
           <RefinementList
             limit={40}
             attribute="topics"
@@ -196,8 +199,6 @@ class ConferencePage extends Component<ComposedProps, State> {
             transformItems={transformCountryRefinements}
             defaultRefinement={countries}
           />
-
-          <Search />
 
           <CurrentRefinements transformItems={transformCurrentRefinements} />
 


### PR DESCRIPTION
**Problem**
When typing in the search bar, it filters the refinement list above, and makes the page jump around. By moving the search bar at the top, the problem disappear. See:

![image](https://user-images.githubusercontent.com/445045/76704946-b85a8600-66dc-11ea-89d1-191592d770ee.png)

@prigara @cgrail what do you think?