### PR TITLE
Make URL check case sensitive again

### DIFF
--- a/src/components/ConferenceNewPage/ConferenceNewPage.tsx
+++ b/src/components/ConferenceNewPage/ConferenceNewPage.tsx
@@ -19,7 +19,7 @@ const SORTED_TOPICS_KEYS = sortBy(Object.keys(TOPICS), (x) =>
   TOPICS[x].toLocaleLowerCase()
 )
 const LOCATION_ONLINE_REGEX = /online|remote|everywhere|world|web|global|virtual|www|http/i
-const VALID_URL_REGEX = /^http(s?):\/\//i
+const VALID_URL_REGEX = /^http(s?):\/\//
 const URL_PARAMETER_REGEX = /\?/
 const URL_SHORTENER_REGEX = /(\/bitly)|(\/bit\.ly)|(\/t\.co)/i
 const TWITTER_REGEX = /@(\w){1,15}$/


### PR DESCRIPTION
It screws up the backend: https://github.com/tech-conferences/conference-data/pull/3101