### PR TITLE
Add non-breakable space between month and date

### DIFF
--- a/src/scenes/ConferenceList/components/ConferenceItem/utils.ts
+++ b/src/scenes/ConferenceList/components/ConferenceItem/utils.ts
@@ -15,18 +15,18 @@ export function formatDate(startDate: string, endDate?: string) {
     const endMonth = getMonth(parsedEndDate)
 
     if (startMonth === endMonth) {
-      return `${format(parsedStartDate, 'MMMM d')}${format(
+      return `${format(parsedStartDate, 'MMMM d')}${format(
         parsedEndDate,
         '-d'
       )}`
     } else {
-      return `${format(parsedStartDate, 'MMMM d')}${format(
+      return `${format(parsedStartDate, 'MMMM d')}${format(
         parsedEndDate,
-        ' - MMMM d'
+        ' - MMMM d'
       )}`
     }
   } else {
-    return format(parsedStartDate, 'MMMM d')
+    return format(parsedStartDate, 'MMMM d')
   }
 }
 


### PR DESCRIPTION
Before

<img width="421" alt="Screenshot 2022-09-29 at 10 05 12" src="https://user-images.githubusercontent.com/445045/193053523-5df11748-a5e3-4267-972c-8d9f816845ca.png">

After

<img width="420" alt="Screenshot 2022-09-29 at 10 05 18" src="https://user-images.githubusercontent.com/445045/193053519-8eadcddf-6efd-4be3-b030-ebe76623e1cb.png">
