### PR TITLE
Scroll to top when changing page

### DIFF
--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+import { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { Head } from 'src/components'
 import { Header, Footer } from 'src/components'
@@ -22,6 +23,11 @@ const Page: React.FC<ComposedProps> = ({
   children,
   ...headerProps
 }) => {
+  // Scroll to top when changing page
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
   return (
     <div>
       <Head />


### PR DESCRIPTION
Currently, when clicking on a link that's a page, the scroll stays where you are, which makes you land in the middle of the page.