### PR TITLE
Mute conference footer links

### DIFF
--- a/src/components/Link/Link.module.scss
+++ b/src/components/Link/Link.module.scss
@@ -14,3 +14,11 @@
 .unstyled {
   text-decoration: none;
 }
+
+.muted {
+  color: color(gray);
+
+  :global(.theme--dark) & {
+    color: color(gray);
+  }
+}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -13,6 +13,7 @@ interface Props {
   unstyled?: boolean
   onClick?: React.MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>
   children: React.ReactNode
+  muted?: boolean
 }
 
 const BtnLink: React.FC<Partial<Props>> = ({
@@ -57,6 +58,7 @@ const Link: React.FC<Props> = ({
   button,
   children,
   unstyled = false,
+  muted = false,
 }) => {
   if (routed) {
     return (
@@ -80,6 +82,7 @@ const Link: React.FC<Props> = ({
         [styles.Selected]: selected,
         [styles.Link]: !unstyled,
         [styles.unstyled]: unstyled,
+        [styles.muted]: muted,
       })}
       onClick={onClick}
       onTouchStart={

--- a/src/scenes/ConferenceList/components/ConferenceItem/ConferenceItem.module.scss
+++ b/src/scenes/ConferenceList/components/ConferenceItem/ConferenceItem.module.scss
@@ -62,3 +62,7 @@
     margin-left: 0;
   }
 }
+
+.muted {
+  color: color(gray);
+}

--- a/src/scenes/ConferenceList/components/ConferenceItem/ConferenceItem.tsx
+++ b/src/scenes/ConferenceList/components/ConferenceItem/ConferenceItem.tsx
@@ -85,8 +85,10 @@ export default class ConferenceItem extends PureComponent<Props & Conference> {
             <>
               <dt className='visuallyHidden'>Link to code of conduct</dt>
               <dd>
-                <span aria-hidden='true'>・</span>
-                <Link url={cocUrl} external>
+                <span className={styles.muted} aria-hidden='true'>
+                  ・
+                </span>
+                <Link url={cocUrl} external muted>
                   Code Of Conduct
                 </Link>
               </dd>
@@ -111,7 +113,7 @@ function Twitter({ twitter }: TwitterProps) {
       <dt className='visuallyHidden'>Twitter username</dt>
       <dd>
         <span aria-hidden='true'>・</span>
-        <Link url={`https://twitter.com/${twitter}`} external>
+        <Link url={`https://twitter.com/${twitter}`} external muted>
           {twitter}
         </Link>
       </dd>


### PR DESCRIPTION
In order to improve the scannability of the list, I believe muting twitter and CoC links will be better.

<img width="756" alt="image" src="https://user-images.githubusercontent.com/445045/201387203-cb3ad078-2fe1-45a6-a6b7-370c21003209.png">


<img width="735" alt="image" src="https://user-images.githubusercontent.com/445045/201387260-0cfe87af-12f2-48a0-94c5-29cdf0915d82.png">
