### PR TITLE
Remove devternity and JDKon

### DIFF
--- a/src/components/SponsoredConference/sponsors.json
+++ b/src/components/SponsoredConference/sponsors.json
@@ -1,14 +1,5 @@
 [
   {
-    "name": "DevTernity",
-    "conferenceDate": "December 8, 2022 ・ Online",
-    "img": "/sponsors/devternity.jpg",
-    "url": "https://devternity.com",
-    "tagline": "Turning developers into architects and engineering leaders",
-    "sponsorDateStart": "2022-01-02",
-    "sponsorDateEnd": "2022-12-01"
-  },
-  {
     "name": "DevDays & DevOps Pro Europe 2023",
     "conferenceDate": "May 23-24 ・ Online — May 25-26 ・ Vilnius, Lithuania",
     "img": "/sponsors/2023-testcon-devdays.jpg",
@@ -16,24 +7,6 @@
     "tagline": "Two conferences held in one location",
     "sponsorDateStart": "2022-12-01",
     "sponsorDateEnd": "2023-06-01"
-  },
-  {
-    "name": "DevTernity",
-    "conferenceDate": "December 7-8, 2023 ・ Online",
-    "img": "/sponsors/devternity.jpg",
-    "url": "https://devternity.com",
-    "tagline": "Turning developers into architects and engineering leaders",
-    "sponsorDateStart": "2023-06-01",
-    "sponsorDateEnd": "2023-11-27"
-  },
-  {
-    "name": "JDKon 2024",
-    "conferenceDate": "May 23-24 ・ Online",
-    "img": "/sponsors/jdkon.jpg",
-    "url": "https://jdkon.io",
-    "tagline": "The place where professional Java developers grow.",
-    "sponsorDateStart": "2023-11-28",
-    "sponsorDateEnd": "2024-01-01"
   },
   {
     "name": "JSNation",
@@ -44,15 +17,6 @@
     "tagline": "Gathering 1,500 people in Amsterdam and 10,000 developers remotely. Amsterdam festival vibe with city boat tours and the biggest JS party.",
     "sponsorDateStart": "2023-01-01",
     "sponsorDateEnd": "2024-02-01"
-  },
-  {
-    "name": "JDKon 2024",
-    "conferenceDate": "May 23-24 ・ Online",
-    "img": "/sponsors/jdkon.jpg",
-    "url": "https://jdkon.io",
-    "tagline": "The place where professional Java developers grow.",
-    "sponsorDateStart": "2024-02-01",
-    "sponsorDateEnd": "2024-03-01"
   },
   {
     "name": "GitNation",
@@ -83,15 +47,6 @@
     "sponsorDateEnd": "2024-06-01"
   },
   {
-    "name": "DevTernity",
-    "conferenceDate": "December, 2024 ・ Online",
-    "img": "/sponsors/devternity.jpg",
-    "url": "https://devternity.com",
-    "tagline": "Turning developers into architects and engineering leaders",
-    "sponsorDateStart": "2024-06-01",
-    "sponsorDateEnd": "2024-09-01"
-  },
-  {
     "name": "GitNation",
     "conferenceDate": "11 remote conferences in 2024",
     "img": "/sponsors/gitnation.jpg",
@@ -99,14 +54,5 @@
     "tagline": "Multi pass from €160 a year - JSNation, React Summit, TypeScript congress and more!",
     "sponsorDateStart": "2024-09-01",
     "sponsorDateEnd": "2024-11-01"
-  },
-  {
-    "name": "DevTernity",
-    "conferenceDate": "December, 2024 ・ Online",
-    "img": "/sponsors/devternity.jpg",
-    "url": "https://devternity.com",
-    "tagline": "Turning developers into architects and engineering leaders",
-    "sponsorDateStart": "2024-11-01",
-    "sponsorDateEnd": "2025-01-01"
   }
 ]

--- a/src/components/SponsoredConference/sponsors.json
+++ b/src/components/SponsoredConference/sponsors.json
@@ -24,7 +24,7 @@
     "url": "https://devternity.com",
     "tagline": "Turning developers into architects and engineering leaders",
     "sponsorDateStart": "2023-06-01",
-    "sponsorDateEnd": "2023-12-01"
+    "sponsorDateEnd": "2023-11-27"
   },
   {
     "name": "JDKon 2024",
@@ -32,7 +32,7 @@
     "img": "/sponsors/jdkon.jpg",
     "url": "https://jdkon.io",
     "tagline": "The place where professional Java developers grow.",
-    "sponsorDateStart": "2023-12-01",
+    "sponsorDateStart": "2023-11-28",
     "sponsorDateEnd": "2024-01-01"
   },
   {


### PR DESCRIPTION
I think we should remove devternity and JDKon:
https://www.theregister.com/2023/11/28/devternity_conference_fake_speakers/