### PR TITLE
Remove prettier dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "jest": "^27.5.1",
         "jsonlint": "^1.6.3",
         "lint-staged": "^9.2.1",
-        "prettier": "^2.2.1",
         "sass": "^1.43.2",
         "source-map-loader": "^0.2.3",
         "tslint": "^4.5.1",
@@ -17417,6 +17416,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "jest": "^27.5.1",
     "jsonlint": "^1.6.3",
     "lint-staged": "^9.2.1",
-    "prettier": "^2.2.1",
     "sass": "^1.43.2",
     "source-map-loader": "^0.2.3",
     "tslint": "^4.5.1",


### PR DESCRIPTION
Will close https://github.com/tech-conferences/confs.tech/pull/596

Couldn't see it being used and noticed this repo is using eslint - perhaps it should be migrated to prettier at some point later on.