### PR TITLE
fix react datepicker arrows

### DIFF
--- a/src/scenes/ConferenceForm/DatePickerOverrides.module.scss
+++ b/src/scenes/ConferenceForm/DatePickerOverrides.module.scss
@@ -11,10 +11,6 @@
     padding: 0.3em 0;
   }
 
-  .react-datepicker__navigation {
-    top: 17px;
-  }
-
   .react-datepicker__day {
     margin: 0;
     padding: 0.166rem;


### PR DESCRIPTION
Before
<img width="314" alt="Screenshot 2024-09-13 at 20 01 26" src="https://github.com/user-attachments/assets/1f52f19b-e071-487e-b3d3-94a5bc39832d">


After
<img width="312" alt="image" src="https://github.com/user-attachments/assets/e267fc14-91f6-49fa-8e9d-7cd2bf4b54fe">
