### PR TITLE
Align Github star

### DIFF
--- a/src/components/GithubStar/GithubStar.module.scss
+++ b/src/components/GithubStar/GithubStar.module.scss
@@ -4,4 +4,6 @@
   display: inline-block;
   vertical-align: middle;
   margin: 0;
+  position: relative;
+  top: 3px;
 }


### PR DESCRIPTION
Before
<img width="607" alt="image" src="https://github.com/user-attachments/assets/e7f4557b-a953-4659-ae6e-86789b5a449b">

After
<img width="640" alt="image" src="https://github.com/user-attachments/assets/3434073e-cc0f-45ee-969e-1d928ab9199b">

Tested on Chrome and Safari