### PR TITLE
feat: Twitter Button Cookie Integration

### DIFF
--- a/src/components/TwitterFollowButton/TwitterFollowButton.tsx
+++ b/src/components/TwitterFollowButton/TwitterFollowButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Helmet from 'react-helmet'
 
 declare global {
@@ -10,12 +10,45 @@ declare global {
     }
   }
 }
+
 const Twitter = () => {
+  const [hasConsent, setHasConsent] = useState(false)
+
   useEffect(() => {
-    if (window.twttr) {
+    // Check if user has consented to cookies
+    const cookieConsent = localStorage.getItem('cookieConsent')
+    if (cookieConsent === 'true') {
+      setHasConsent(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasConsent && window.twttr) {
       window.twttr.widgets.load()
     }
-  })
+  }, [hasConsent])
+
+  // If no consent, show a simple follow link without embedded widget
+  if (!hasConsent) {
+    return (
+      <a
+        href='https://twitter.com/ConfsTech'
+        target='_blank'
+        rel='noopener noreferrer'
+        style={{
+          display: 'inline-block',
+          padding: '6px 12px',
+          backgroundColor: '#1da1f2',
+          color: 'white',
+          textDecoration: 'none',
+          borderRadius: '4px',
+          fontSize: '14px',
+        }}
+      >
+        Follow @ConfsTech
+      </a>
+    )
+  }
 
   return (
     <>
@@ -24,6 +57,7 @@ const Twitter = () => {
           async
           defer
           src='https://platform.twitter.com/widgets.js'
+          data-cookieconsent='ignore'
         ></script>
       </Helmet>
 
@@ -32,6 +66,7 @@ const Twitter = () => {
         data-show-screen-name='false'
         className='twitter-follow-button'
         data-show-count='true'
+        data-dnt='true'
       >
         Follow @ConfsTech
       </a>


### PR DESCRIPTION
## Twitter Button Cookie Integration

This PR ensures the Twitter follow button respects user cookie preferences.

- Check cookie consent before loading Twitter widgets
- Display simple follow link if consent is not given
- Add data-cookieconsent='ignore' attribute for cookie banner compatibility
- Prevent automatic Twitter widget loading when user declines cookies

Breaking down #1021 

----
This pull request updates the `TwitterFollowButton` component to respect user cookie consent preferences and improve privacy compliance. The changes introduce a mechanism to check for cookie consent before loading Twitter widgets and provide an alternative follow link when consent is not given.

### Privacy compliance and cookie consent:

* [`src/components/TwitterFollowButton/TwitterFollowButton.tsx`](diffhunk://#diff-cf1d0f26002d781fa64aa9051be109e011e41135655f64cb76c2279193c2d65fL1-R1): Added a `useState` hook to manage cookie consent (`hasConsent`) and updated the `useEffect` hook to check `localStorage` for user consent before loading Twitter widgets. If consent is not given, a simple follow link is displayed instead of the embedded widget. [[1]](diffhunk://#diff-cf1d0f26002d781fa64aa9051be109e011e41135655f64cb76c2279193c2d65fL1-R1) [[2]](diffhunk://#diff-cf1d0f26002d781fa64aa9051be109e011e41135655f64cb76c2279193c2d65fR13-R51)

### Enhancements to Twitter widget attributes:

* [`src/components/TwitterFollowButton/TwitterFollowButton.tsx`](diffhunk://#diff-cf1d0f26002d781fa64aa9051be109e011e41135655f64cb76c2279193c2d65fR60): Added `data-cookieconsent='ignore'` to the Twitter widget script tag to ensure it doesn't interfere with cookie consent mechanisms.
* [`src/components/TwitterFollowButton/TwitterFollowButton.tsx`](diffhunk://#diff-cf1d0f26002d781fa64aa9051be109e011e41135655f64cb76c2279193c2d65fR69): Added `data-dnt='true'` to the Twitter follow button to enable Do Not Track functionality for enhanced privacy.