### PR TITLE
fix: downgrade css-loader to version 6.11.0 for compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "case-sensitive-paths-webpack-plugin": "^2.4.0",
         "chalk": "5.4.1",
         "classnames": "^2.2.5",
-        "css-loader": "^7.1.2",
+        "css-loader": "^6.11.0",
         "css-minimizer-webpack-plugin": "^7.0.2",
         "date-fns": "^4.1.0",
         "dotenv": "^17.0.1",
@@ -8874,9 +8874,9 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
-      "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.11.0.tgz",
+      "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
       "license": "MIT",
       "dependencies": {
         "icss-utils": "^5.1.0",
@@ -8889,7 +8889,7 @@
         "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">= 18.12.0"
+        "node": ">= 12.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8897,7 +8897,7 @@
       },
       "peerDependencies": {
         "@rspack/core": "0.x || 1.x",
-        "webpack": "^5.27.0"
+        "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@rspack/core": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "chalk": "5.4.1",
     "classnames": "^2.2.5",
-    "css-loader": "^7.1.2",
+    "css-loader": "^6.11.0",
     "css-minimizer-webpack-plugin": "^7.0.2",
     "date-fns": "^4.1.0",
     "dotenv": "^17.0.1",


### PR DESCRIPTION
closes #1030

This pull request includes a dependency update in the `package.json` file, specifically downgrading the `css-loader` package from version `^7.1.2` to version `^6.11.0`.