### PR TITLE
fix: enhance Heroku server routing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,7 +63,7 @@
     "array-callback-return": "off",
     "no-process-env": "off",
     "space-before-function-paren": ["error", {
-      "anonymous": "never",
+      "anonymous": "always",
       "named": "never",
       "asyncArrow": "always"
     }],

--- a/scripts/heroku-start.js
+++ b/scripts/heroku-start.js
@@ -7,11 +7,25 @@ app.use(express.json())
 // Your static pre-build assets folder
 app.use(express.static(path.join(__dirname, '..', 'build')))
 // Root Redirects to the pre-build assets
-app.get('/', function(req, res) {
+app.get('/', function (req, res) {
   res.sendFile(path.join(__dirname, '..', 'build/index.html'))
 })
-// Any Page Redirects to the pre-build assets folder index.html that // will load the react app
-app.get('*', function(req, res) {
+
+// Specific routes for common React Router patterns
+app.get('/about', function (req, res) {
+  res.sendFile(path.join(__dirname, '..', 'build/index.html'))
+})
+
+app.get('/contact', function (req, res) {
+  res.sendFile(path.join(__dirname, '..', 'build/index.html'))
+})
+
+// More specific catch-all for React Router
+// This avoids the problematic '*' pattern
+app.get('/:path', function (req, res) {
+  res.sendFile(path.join(__dirname, '..', 'build/index.html'))
+})
+app.get('/:path/:subpath', function (req, res) {
   res.sendFile(path.join(__dirname, '..', 'build/index.html'))
 })
 app.listen(port, () => {


### PR DESCRIPTION
Fix Express 5.x compatibility - replace app.get('*') with middleware

update ESLint rule for space before function parentheses;
#1043

This pull request includes updates to improve code style consistency and enhance route handling in a React app hosted on Heroku. The most important changes involve modifying ESLint rules for function spacing and restructuring route handling to better support React Router patterns.

### Code style updates:
* [`.eslintrc`](diffhunk://#diff-e7e195d3d8fa5b82fa51ed952f3a179d429cbc46c0432ce1f7b357c54c162822L66-R66): Updated the `space-before-function-paren` rule to require spaces before parentheses in anonymous functions, aligning with the project's preferred code style.

### Route handling improvements:
* [`scripts/heroku-start.js`](diffhunk://#diff-bba5fda472d4ce7689fcccc16d8abd5b5302bb364c04f70dab2bc4142cd2fcd9L13-R28): Replaced the generic `'*'` catch-all route with more specific routes (`/about`, `/contact`, and parameterized routes like `/:path` and `/:path/:subpath`) to better support React Router patterns and avoid potential issues with overly broad route matching.